### PR TITLE
calendar workflow on new codebase

### DIFF
--- a/.claude-mistakes.md
+++ b/.claude-mistakes.md
@@ -48,11 +48,20 @@ for (const topic of activeTopics) {
 **Correct approach:** Pass topicId in OAuth state, continue only that specific topic
 **Rule:** Always maintain context specificity, never broadcast when targeting is needed
 
-### 5. Slack Message Pattern - ack() + postMessage()
-**Mistake:** Used separate `ack()` and `client.chat.postMessage()`
-**Why wrong:** Two operations when one suffices
-**Correct approach:** `ack({ text: "message" })`
-**Rule:** Use Slack's built-in patterns rather than composing primitives
+### 5. Composing Primitives Instead of Using Framework Features
+**Mistake:** Used separate `ack()` and `client.chat.postMessage()` calls
+```ts
+// WRONG: Composing primitives
+await ack()
+await client.chat.postMessage({ text: "message" })
+```
+**Why wrong:** Two operations, more failure points, ignores framework capabilities
+**Correct approach:** Use built-in framework features
+```ts  
+// CORRECT: Single operation using framework capability
+await ack({ text: "message" })
+```
+**Rule:** Learn what frameworks can do - don't just compose lower-level operations
 
 ### 6. Over-Exporting Functions
 **Mistake:** Exported internal helper functions unnecessarily
@@ -69,6 +78,9 @@ export async function findActiveTopicsForUser(...)
 async function shouldSuppressCalendarPrompt(...)
 async function hasUserBeenPrompted(...)
 ```
+
+### 7. Pointless Indirection
+**Rule:** Write human-like code. Don't add pointless indirection, keep things simple.
 
 ---
 

--- a/.claude-mistakes.md
+++ b/.claude-mistakes.md
@@ -1,0 +1,80 @@
+# Claude Mistakes Log
+
+This file tracks coding mistakes to avoid repeating them. Not committed to git.
+
+## 2025-08-26 - Calendar Buttons Implementation
+
+### 1. Terrible Error Handling - "User" Fallback
+**Mistake:** Used `|| 'User'` fallback for undefined realName
+```ts
+userNames: [userMap.get(message.userId)?.realName || 'User']
+```
+**Why wrong:** 
+- Message fails to send (no user named 'User')
+- Could send to wrong person if someone named 'User' exists
+- Masks real data problems
+
+**Correct approach:** Fail fast with descriptive error
+```ts
+const userName = userMap.get(message.userId)?.realName
+if (!userName) {
+  throw new Error(`User ${message.userId} has no realName in userMap`)
+}
+```
+**Rule:** Never use generic fallbacks for user identification. Always throw errors.
+
+### 2. Over-exporting Functions
+**Mistake:** Exported internal helper functions unnecessarily
+- `shouldSuppressCalendarPrompt`
+- `hasUserBeenPrompted` 
+- `findActiveTopicsForUser`
+
+**Why wrong:** Creates false public API, harder to refactor
+**Rule:** Only export what's actually used externally
+
+### 3. Unnecessary Variable Assignments
+**Mistake:** Created `messageToSend` variable when `messageGroup.text` was cleaner
+**Why wrong:** Extra complexity for no benefit
+**Rule:** Don't create variables unless they add clarity or avoid repetition
+
+### 4. Architectural Flaw - Shotgun Workflow Continuation
+**Mistake:** Sent continuation messages to ALL active topics for user
+```ts
+for (const topic of activeTopics) {
+  // Send message to each topic - WRONG
+}
+```
+**Why wrong:** User gets spammed, wrong topics get continued
+**Correct approach:** Pass topicId in OAuth state, continue only that specific topic
+**Rule:** Always maintain context specificity, never broadcast when targeting is needed
+
+### 5. Slack Message Pattern - ack() + postMessage()
+**Mistake:** Used separate `ack()` and `client.chat.postMessage()`
+**Why wrong:** Two operations when one suffices
+**Correct approach:** `ack({ text: "message" })`
+**Rule:** Use Slack's built-in patterns rather than composing primitives
+
+### 6. Over-Exporting Functions
+**Mistake:** Exported internal helper functions unnecessarily
+```ts
+// WRONG: Exported functions only used within the same file
+export async function shouldSuppressCalendarPrompt(...) 
+export async function hasUserBeenPrompted(...)
+export async function findActiveTopicsForUser(...)
+```
+**Why wrong:** Creates false public API, harder to refactor, suggests external use
+**Rule:** Follow Ben's pattern - only export what other files actually import
+```ts
+// CORRECT: Internal helpers are not exported
+async function shouldSuppressCalendarPrompt(...)
+async function hasUserBeenPrompted(...)
+```
+
+---
+
+## General Patterns to Avoid
+- Generic string fallbacks for user data
+- Over-exporting internal functions  
+- Creating variables that don't add value
+- Broadcasting when targeting is needed
+- Composing primitives when built-in patterns exist

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@slack/bolt": "4.4.0",
     "@slack/web-api": "7.9.3",
     "ai": "4.3.19",
-    "better-auth": "^1.3.7",
+    "better-auth": "1.3.7",
     "drizzle-orm": "0.44.3",
     "googleapis": "155.0.0",
     "hono": "4.9.1",

--- a/src/agents/analyze-topic-relevance.ts
+++ b/src/agents/analyze-topic-relevance.ts
@@ -86,7 +86,7 @@ export async function analyzeTopicRelevance(topics: Topic[], message: SlackMessa
   const callingUserTimezone = callingUser[0]?.tz || 'UTC'
 
   // Get channel information for descriptive display
-  const channelDescription = await getChannelDescription(message.channelId, userMap, botUserId)
+  const channelDescription = await getChannelDescription(message.channelId, userMap)
 
   // Fetch recent messages for each topic in the same channel
   const topicMessagesMap = new Map<string, SlackMessage[]>()
@@ -151,7 +151,7 @@ ${(await Promise.all(topics.map(async (topic, i) => {
   // Get recent messages for this topic
   const recentMessages = topicMessagesMap.get(topic.id) || []
   const messagesFormatted = recentMessages.length > 0
-    ? `\n   Recent messages in this channel:\n${(await organizeMessagesByChannelAndThread(recentMessages, botUserId, callingUserTimezone)).split('\n').map((line) => '   ' + line).join('\n')}`
+    ? `\n   Recent messages in this channel:\n${(await organizeMessagesByChannelAndThread(recentMessages, callingUserTimezone)).split('\n').map((line) => '   ' + line).join('\n')}`
     : ''
   return `${i + 1}. Topic ID: ${topic.id}
    Summary: ${topic.summary}

--- a/src/agents/schedule-next-step.ts
+++ b/src/agents/schedule-next-step.ts
@@ -492,11 +492,16 @@ export async function scheduleNextStep(
      message.text.toLowerCase().includes('send me'))
 
   if (userRequestingCalendar) {
+    const userName = userMap.get(message.userId)?.realName
+    if (!userName) {
+      throw new Error(`User ${message.userId} has no realName in userMap`)
+    }
+    
     return {
       replyMessage: '',
       messagesToUsers: [
         {
-          userNames: [userMap.get(message.userId)?.realName || 'User'],
+          userNames: [userName],
           text: 'Here are your Google Calendar connection options. Connecting will allow me to check your availability automatically when scheduling.',
           includeCalendarButtons: true,
         },

--- a/src/agents/schedule-next-step.ts
+++ b/src/agents/schedule-next-step.ts
@@ -484,7 +484,6 @@ export async function scheduleNextStep(
   topic: Topic,
   previousMessages: SlackMessage[],
   userMap: Map<string, SlackUser>,
-  botUserId: string,
 ): Promise<ScheduleNextStepRes> {
   // If user is explicitly asking for calendar connection, send link immediately
   const userRequestingCalendar = message.text.toLowerCase().includes('calendar') &&
@@ -511,12 +510,12 @@ export async function scheduleNextStep(
   const callingUserTimezone = callingUser?.tz || 'UTC'
 
   // Get channel information for descriptive display
-  const channelDescription = await getChannelDescription(message.channelId, userMap, botUserId)
+  const channelDescription = await getChannelDescription(message.channelId, userMap)
 
-  const userPrompt = `Your name in conversations: ${userMap.get(botUserId)?.realName || 'Assistant'}
+  const userPrompt = `Your name in conversations: ${userMap.get(topic.botUserId)?.realName || 'Assistant'}
 
 Previous Messages in this Topic:
-${await organizeMessagesByChannelAndThread(previousMessages, botUserId, callingUserTimezone)}
+${await organizeMessagesByChannelAndThread(previousMessages, callingUserTimezone)}
 
 Message To Reply To:
 From: ${userMap.get(message.userId)?.realName || 'Unknown User'} (Timezone: ${callingUser?.tz ? getShortTimezoneFromIANA(callingUserTimezone) : 'Unknown'})

--- a/src/agents/schedule-next-step.ts
+++ b/src/agents/schedule-next-step.ts
@@ -13,7 +13,7 @@ import {
 } from '../utils'
 import { getShortTimezoneFromIANA, mergeCalendarWithOverrides } from '@shared/utils'
 import { CalendarEvent } from '@shared/api-types'
-import { generateGoogleAuthUrl, getUserCalendarStructured, isCalendarConnected, updateTopicUserContext } from '../calendar-service'
+import { getUserCalendarStructured, isCalendarConnected, updateTopicUserContext } from '../calendar-service'
 import { findCommonFreeTime, UserProfile, convertCalendarEventsToUserProfile } from '../tools/time_intersection'
 
 interface ScheduleNextStepContext {
@@ -253,6 +253,7 @@ const ScheduleNextStepRes = z.strictObject({
   messagesToUsers: z.array(z.strictObject({
     userNames: z.array(z.string()),
     text: z.string(),
+    includeCalendarButtons: z.boolean().optional(),
   })).optional().nullable(),
   groupMessage: z.string().optional().nullable(),
   reasoning: z.string(),
@@ -492,15 +493,16 @@ export async function scheduleNextStep(
      message.text.toLowerCase().includes('send me'))
 
   if (userRequestingCalendar) {
-    const authUrl = generateGoogleAuthUrl(message.userId)
-
     return {
-      replyMessage: `Here's your Google Calendar connection link:
-
-${authUrl}
-
-This will allow me to check your availability automatically when scheduling. If you'd rather not connect your calendar, just let me know and I'll ask for your availability manually instead.`,
-      reasoning: 'User explicitly requested calendar connection link',
+      replyMessage: '',
+      messagesToUsers: [
+        {
+          userNames: [userMap.get(message.userId)?.realName || 'User'],
+          text: 'Here are your Google Calendar connection options. Connecting will allow me to check your availability automatically when scheduling.',
+          includeCalendarButtons: true,
+        },
+      ],
+      reasoning: 'User explicitly requested calendar connection - showing fancy buttons',
     }
   }
 

--- a/src/calendar-service.ts
+++ b/src/calendar-service.ts
@@ -105,7 +105,7 @@ export async function updateTopicUserContext(topicId: string, slackUserId: strin
 /**
  * Check if a user has opted out of calendar prompts
  */
-export async function shouldSuppressCalendarPrompt(slackUserId: string): Promise<boolean> {
+async function shouldSuppressCalendarPrompt(slackUserId: string): Promise<boolean> {
   const context = await getUserContext(slackUserId)
   return !!context.suppressCalendarPrompt
 }
@@ -120,7 +120,7 @@ export async function setSuppressCalendarPrompt(slackUserId: string, suppress: b
 /**
  * Check if a user has been prompted for calendar connection in a specific topic
  */
-export async function hasUserBeenPrompted(topicId: string, userId: string): Promise<boolean> {
+async function hasUserBeenPrompted(topicId: string, userId: string): Promise<boolean> {
   const [topic] = await db
     .select()
     .from(topicTable)
@@ -165,7 +165,7 @@ export async function shouldShowCalendarButtons(
 /**
  * Find active scheduling topics that include a specific user
  */
-export async function findActiveTopicsForUser(slackUserId: string) {
+async function findActiveTopicsForUser(slackUserId: string) {
   const activeTopics = await db
     .select()
     .from(topicTable)
@@ -204,7 +204,10 @@ export async function continueSchedulingWorkflow(slackUserId: string) {
       .where(eq(slackUserTable.id, slackUserId))
       .limit(1)
 
-    const userName = slackUser?.realName || 'User'
+    const userName = slackUser?.realName
+    if (!userName) {
+      throw new Error(`User ${slackUserId} has no realName in database`)
+    }
 
     // For each active topic, create a synthetic calendar connection message and process it
     for (const topic of activeTopics) {

--- a/src/db/migrations/0017_add_bot_user_id_to_topic.sql
+++ b/src/db/migrations/0017_add_bot_user_id_to_topic.sql
@@ -1,0 +1,8 @@
+-- First add the column as nullable
+ALTER TABLE "topic" ADD COLUMN "bot_user_id" text;
+
+-- Set bot_user_id to 'UTESTBOT' for all existing topics
+UPDATE "topic" SET "bot_user_id" = 'UTESTBOT';
+
+-- Now make the column not nullable
+ALTER TABLE "topic" ALTER COLUMN "bot_user_id" SET NOT NULL;

--- a/src/db/migrations/meta/0017_snapshot.json
+++ b/src/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,635 @@
+{
+  "id": "bef219a1-0e03-40f8-a381-360a9e1097d1",
+  "prevId": "2aef4a18-dff4-49c6-b6d3-e865a9442542",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel": {
+      "name": "slack_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_ids": {
+          "name": "user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_message": {
+      "name": "slack_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_ts": {
+          "name": "raw_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_message_topic_id_topic_id_fk": {
+          "name": "slack_message_topic_id_topic_id_fk",
+          "tableFrom": "slack_message",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user": {
+      "name": "slack_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_ids": {
+          "name": "user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "per_user_context": {
+          "name": "per_user_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_data": {
+      "name": "user_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_data_slack_user_id_slack_user_id_fk": {
+          "name": "user_data_slack_user_id_slack_user_id_fk",
+          "tableFrom": "user_data",
+          "tableTo": "slack_user",
+          "columnsFrom": [
+            "slack_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_data_slack_user_id_unique": {
+          "name": "user_data_slack_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1756149867524,
       "tag": "0016_add_better_auth_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1756188243755,
+      "tag": "0017_add_bot_user_id_to_topic",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/main.ts
+++ b/src/db/schema/main.ts
@@ -15,6 +15,7 @@ export type WorkflowType = 'scheduling' | 'other'
 export const topicTable = pgTable('topic', {
   id: uuid().primaryKey().defaultRandom(),
   userIds: jsonb().$type<string[]>().notNull().default([]),
+  botUserId: text().notNull(),
   summary: text().notNull(),
   workflowType: text().$type<WorkflowType>().notNull().default('other'),
   isActive: boolean().notNull().default(true),

--- a/src/evals/flack-eval-dual-mode.ts
+++ b/src/evals/flack-eval-dual-mode.ts
@@ -10,8 +10,6 @@ import { unserializeTopicData, TopicData } from '@shared/api-types'
 import { setupCalendarDataForEval } from './setup-calendar-data'
 
 
-const BOT_USER_ID = 'UTESTBOT'
-
 type EvalMode = 'persona' | 'calendar'
 
 // Simulate a scheduling conversation using personas or calendar mode
@@ -62,7 +60,7 @@ async function simulateSchedulingConversation(
     throw new Error('Eval requires at least 1 test user')
   }
 
-  const initMessage = `<@${BOT_USER_ID}> Can you help us schedule a 1-hour meeting for Tuesday? We need ${testCase.profiles.map((p) => p.name).join(', ')} to attend.`
+  const initMessage = `Can you help us schedule a 1-hour meeting for Tuesday? We need ${testCase.profiles.map((p) => p.name).join(', ')} to attend.`
   console.log(`Sending initial message from ${userIds[0]}: ${initMessage}`)
 
   const initMessageRes = await api.message.$post({
@@ -105,8 +103,7 @@ async function simulateSchedulingConversation(
 
         // Generate response from all non-bot users in channel
         const { userIds } = await channelRes.json()
-        const usersToReply = userIds.filter((userId) => userId !== BOT_USER_ID)
-        return Promise.all(usersToReply.map(async (userId) => {
+        return Promise.all(userIds.map(async (userId) => {
           const profile = userIdProfileMap.get(userId)
           if (!profile) {
             throw new Error(`Profile not found for userId: ${userId}`)

--- a/src/flack-helpers.ts
+++ b/src/flack-helpers.ts
@@ -16,12 +16,7 @@ import {
 export const BOT_USER_ID = 'UTESTBOT'
 
 export async function getOrCreateChannelForUsers(userIds: string[]): Promise<string> {
-  // Ensure bot is included in list of users
-  if (!userIds.includes(BOT_USER_ID)) {
-    userIds.push(BOT_USER_ID)
-  }
-
-  // Sort userIds for consistent comparison
+  // Sort userIds for consistent comparison (bot is NOT included)
   const sortedUserIds = [...userIds].sort()
 
   // Use transaction with a simple advisory lock for channel creation
@@ -176,7 +171,7 @@ export const mockSlackClient = {
         text: params.text,
         ts: timestamp,
         thread_ts: params.thread_ts,
-        user: BOT_USER_ID,
+        user: '', // This field is not used by the caller downstream
         channel_type: params.channel.startsWith('D') ? 'im' : 'channel',
         event_ts: timestamp,
       }

--- a/src/frontend/Topic.tsx
+++ b/src/frontend/Topic.tsx
@@ -273,29 +273,25 @@ function Topic() {
   // Check if we're viewing the latest message
   const isViewingLatest = timelinePosition === sortedMessages.length - 1
 
-  // Helper to check if a channel is a DM (2 users)
+  // Helper to check if a channel is a DM (1 user since bot is not included)
   const isDMChannel = (channelId: string) => {
     const channel = topicData.channels?.find((ch) => ch.id === channelId)
-    return channel?.userIds.length === 2
+    return channel?.userIds.length === 1
   }
 
   // Helper to get the current user ID for a channel
   const getCurrentUserId = (channelId: string) => {
     const channel = topicData.channels?.find((ch) => ch.id === channelId)
-    return channel?.userIds.find((uid) => userMap.has(uid))
+    return channel?.userIds[0]
   }
 
   // Helper to get DM user info (for channel title)
   const getDMUserInfo = (channelId: string) => {
     const channel = topicData.channels?.find((ch) => ch.id === channelId)
-    if (!channel || channel.userIds.length !== 2) return null
-
-    // Find the non-bot user ID (the one in userMap)
-    const userId = channel.userIds.find((uid) => userMap.has(uid))
-    if (!userId) return null
+    if (!channel || channel.userIds.length !== 1) return null
 
     // Get the user details
-    const user = topicData.users.find((u) => u.id === userId)
+    const user = topicData.users.find((u) => u.id === channel.userIds[0])
     if (!user) return null
 
     return {

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -33,6 +33,7 @@ export interface UserContext {
   slackTeamId?: string
   slackUserName?: string
   slackDisplayName?: string
+  suppressCalendarPrompt?: boolean
 }
 
 export interface TopicUserContext {

--- a/src/slack-bot.ts
+++ b/src/slack-bot.ts
@@ -24,9 +24,7 @@ slackApp.message(async ({ message, context, client }) => {
 })
 
 // Handle interactive components (buttons)
-slackApp.action('dont_ask_calendar_again', async ({ ack, body, client }) => {
-  await ack()
-
+slackApp.action('dont_ask_calendar_again', async ({ ack, body }) => {
   try {
     // Extract user ID from the action
     const userId = body.user.id
@@ -34,17 +32,15 @@ slackApp.action('dont_ask_calendar_again', async ({ ack, body, client }) => {
     // Set the suppression flag
     await setSuppressCalendarPrompt(userId, true)
 
-    // Send confirmation message in the same channel
-    if (body.channel?.id) {
-      await client.chat.postMessage({
-        channel: body.channel.id,
-        text: '✅ Got it! I won\'t ask you to connect your calendar again unless you explicitly ask me to.',
-      })
-    }
+    // Acknowledge with confirmation message (replaces empty ack + postMessage)
+    await ack({ 
+      text: '✅ Got it! I won\'t ask you to connect your calendar again unless you explicitly ask me to.' 
+    })
 
     console.log(`User ${userId} opted out of calendar prompts`)
   } catch (error) {
     console.error('Error handling dont_ask_calendar_again action:', error)
+    await ack() // Fallback empty ack on error
   }
 })
 

--- a/src/slack-message-handler.ts
+++ b/src/slack-message-handler.ts
@@ -300,7 +300,7 @@ export async function processSchedulingActions(
 
                 if (shouldShow) {
                   // Generate OAuth URL for direct linking
-                  const authUrl = generateGoogleAuthUrl(userId)
+                  const authUrl = generateGoogleAuthUrl(topicId, userId)
 
                   // Add calendar connection buttons using Block Kit format
                   blocks = [

--- a/src/slack-message-handler.ts
+++ b/src/slack-message-handler.ts
@@ -291,7 +291,6 @@ export async function processSchedulingActions(
               // Only include the actual user, not the bot
               await upsertSlackChannel(dmChannel.channel.id, [userId])
 
-              const messageToSend = messageGroup.text
               let blocks = undefined
 
               // Check if AI requested calendar buttons for this message
@@ -352,7 +351,7 @@ export async function processSchedulingActions(
               // Send the message with optional blocks
               const dmResponse = await client.chat.postMessage({
                 channel: dmChannel.channel.id,
-                text: messageToSend,
+                text: messageGroup.text,
                 ...(blocks && { blocks }),
               })
 
@@ -362,7 +361,7 @@ export async function processSchedulingActions(
                   topicId: topicId,
                   channelId: dmChannel.channel.id,
                   userId: topic.botUserId,
-                  text: messageToSend,
+                  text: messageGroup.text,
                   timestamp: tsToDate(dmResponse.ts),
                   rawTs: dmResponse.ts,
                   threadTs: null,

--- a/src/slack-message-handler.ts
+++ b/src/slack-message-handler.ts
@@ -362,7 +362,7 @@ export async function processSchedulingActions(
                   topicId: topicId,
                   channelId: dmChannel.channel.id,
                   userId: topic.botUserId,
-                  text: messageGroup.text,
+                  text: messageToSend,
                   timestamp: tsToDate(dmResponse.ts),
                   rawTs: dmResponse.ts,
                   threadTs: null,


### PR DESCRIPTION
- Add suppressCalendarPrompt flag to UserContext
- Implement calendar prompt tracking using Ben's perUserContext system
- Consolidate 3 functions in calendar-service.ts into shouldShowCalendarButtons() function
- Add calendar button handlers (Connect, Not now, Don't ask again)
- Update messagesToUsers interface to support calendar buttons
- Add workflow continuation after calendar connection (synthetic message triggers scheduling resume)
- Integrate calendar buttons into slack-message-handler

(calendar-buttons-v2 constitutes all the work on calendar-buttons + the requested edits, but on the updated codebase.)