### PR TITLE
Add meeting-prep workflow type and conversation agent

### DIFF
--- a/src/agents/agent-sdk.ts
+++ b/src/agents/agent-sdk.ts
@@ -5,7 +5,6 @@ import {
   Runner,
   run,
   tool,
-  ModelBehaviorError,
   BatchTraceProcessor,
   setDefaultOpenAIClient,
   setOpenAIAPI,
@@ -35,4 +34,4 @@ setOpenAIAPI('chat_completions')
 setTraceProcessors([traceProcessor])
 
 // Re-export openai agent sdk types
-export { Agent, RunContext, Runner, run, tool, ModelBehaviorError }
+export { Agent, RunContext, Runner, run, tool }

--- a/src/agents/analyze-topic-relevance.ts
+++ b/src/agents/analyze-topic-relevance.ts
@@ -13,11 +13,12 @@ import {
   formatTimestampWithTimezone,
 } from '../utils'
 import { getShortTimezoneFromIANA } from '@shared/utils'
+import { WorkflowType } from '@shared/api-types'
 
 const AnalyzeTopicRes = z.strictObject({
   relevantTopicId: z.string().optional().nullable(),
   suggestedNewTopic: z.string().optional().nullable(),
-  workflowType: z.enum(['scheduling', 'other']).optional().nullable(),
+  workflowType: WorkflowType.optional().nullable(),
   confidence: z.number().min(0).max(1),
   reasoning: z.string(),
 })
@@ -60,7 +61,8 @@ Given a list of existing topics and a new message, determine:
 ## Workflow Type Classification
 When suggesting a new topic, also classify its workflow type:
 - "scheduling": The topic involves planning, organizing, or scheduling meetings, events, or activities (e.g., "plan lunch", "schedule meeting", "organize team event")
-- "other": All other topics that don't involve scheduling or planning activities
+- "meeting-prep": The topic involves preparing for an upcoming meeting by gathering updates, creating agendas, or collecting input from participants (e.g., "prepare agenda for tomorrow's standup", "gather updates for the quarterly review", "compile discussion topics for the team meeting")
+- "other": All other topics that don't involve scheduling or meeting preparation
 
 ## Response Format
 You must respond with ONLY a JSON object - no additional text, markdown formatting, or explanations. Return ONLY valid JSON that can be parsed directly.
@@ -69,7 +71,7 @@ The JSON structure must be:
 {
   "relevantTopicId": "topic-id-2",           // Include only if message is relevant to existing topic
   "suggestedNewTopic": "New topic summary",  // Include only if existingTopicId is not populated
-  "workflowType": "scheduling",              // Include only when suggestedNewTopic is present. Must be "scheduling" or "other"
+  "workflowType": "scheduling",              // Include only when suggestedNewTopic is present. Must be "scheduling", "meeting-prep", or "other"
   "confidence": 0.85,                        // Confidence level between 0 and 1
   "reasoning": "Brief explanation"           // One sentence explaining the decision
 }

--- a/src/agents/conversation-utils.ts
+++ b/src/agents/conversation-utils.ts
@@ -1,0 +1,196 @@
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+
+import type { RunContext } from './agent-sdk'
+import { Agent, Runner, tool } from './agent-sdk'
+import db from '../db/engine'
+import type { Topic, SlackMessage, SlackUser } from '../db/schema/main'
+import { topicTable } from '../db/schema/main'
+import {
+  tsToDate,
+  organizeMessagesByChannelAndThread,
+  replaceUserMentions,
+  getChannelDescription,
+  formatTimestampWithTimezone,
+} from '../utils'
+import { getShortTimezoneFromIANA } from '@shared/utils'
+import { generateGoogleAuthUrl } from '../calendar-service'
+
+export interface ConversationContext {
+  topic: Topic,
+  userMap: Map<string, SlackUser>,
+  callingUserTimezone: string,
+}
+
+export const ConversationRes = z.strictObject({
+  replyMessage: z.string().optional().nullable(),
+  markTopicInactive: z.boolean().optional().nullable(),
+  messagesToUsers: z.array(z.strictObject({
+    userNames: z.array(z.string()),
+    text: z.string(),
+  })).optional().nullable(),
+  groupMessage: z.string().optional().nullable(),
+  reasoning: z.string(),
+})
+export type ConversationRes = z.infer<typeof ConversationRes>
+
+export const ConversationAgent = Agent<ConversationContext, typeof ConversationRes>
+export type ConversationAgent = InstanceType<typeof ConversationAgent>
+
+export const updateUserNames = tool({
+  name: 'updateUserNames',
+  description: 'Update the list of users involved in the topic. Provide the COMPLETE list of user names who should be involved going forward (this replaces the existing list).',
+  parameters: z.strictObject({
+    userNames: z.array(z.string()).describe('Complete list of user names who should be involved (use exact names from User Directory)'),
+  }),
+  execute: async ({ userNames }, runContext?: RunContext<ConversationContext>) => {
+    console.log('Tool called: updateUserNames with names:', userNames)
+
+    if (!runContext) throw new Error('runContext not provided')
+    const { topic, userMap } = runContext.context
+
+    // Map names to user IDs
+    const updatedUserIds: string[] = []
+
+    for (const name of userNames) {
+      let foundId: string | undefined
+      for (const [id, user] of userMap.entries()) {
+        if (user.realName === name) {
+          foundId = id
+          break
+        }
+      }
+
+      if (foundId) {
+        updatedUserIds.push(foundId)
+      } else {
+        throw new Error(`Could not find user ID for name: ${name}`)
+      }
+    }
+
+    // Update the topic in the database with the new user IDs
+    const [updatedTopic] = await db
+      .update(topicTable)
+      .set({
+        userIds: updatedUserIds,
+        updatedAt: new Date(),
+      })
+      .where(eq(topicTable.id, topic.id))
+      .returning()
+
+    // Update runContext with the updated topic
+    runContext.context.topic = updatedTopic
+
+    // Map IDs back to names for the response
+    const updatedUserNames = updatedUserIds.map((id) => userMap.get(id)?.realName || id)
+    return `Updated user list to: ${updatedUserNames.join(', ')}`
+  },
+})
+
+export const updateSummary = tool({
+  name: 'updateSummary',
+  description: 'Update the topic summary when new information clarifies or changes the topic details.',
+  parameters: z.strictObject({
+    summary: z.string().describe('The updated topic summary'),
+  }),
+  execute: async ({ summary }, runContext?: RunContext<ConversationContext>) => {
+    console.log('Tool called: updateSummary with summary:', summary)
+
+    if (!runContext) throw new Error('runContext not provided')
+    const { topic } = runContext.context
+
+    // Update the topic in the database with the new summary
+    const [updatedTopic] = await db
+      .update(topicTable)
+      .set({
+        summary,
+        updatedAt: new Date(),
+      })
+      .where(eq(topicTable.id, topic.id))
+      .returning()
+
+    // Update runContext with the updated topic
+    runContext.context.topic = updatedTopic
+
+    return `Updated topic summary to: ${summary}`
+  },
+})
+
+export async function runConversationAgent(
+  agent: ConversationAgent,
+  message: SlackMessage,
+  topic: Topic,
+  previousMessages: SlackMessage[],
+  userMap: Map<string, SlackUser>,
+): Promise<ConversationRes> {
+  // If user is explicitly asking for calendar connection, send link immediately
+  const userRequestingCalendar = message.text.toLowerCase().includes('calendar') &&
+    (message.text.toLowerCase().includes('link') ||
+     message.text.toLowerCase().includes('connect') ||
+     message.text.toLowerCase().includes('send me'))
+
+  if (userRequestingCalendar) {
+    const authUrl = generateGoogleAuthUrl(message.userId)
+
+    return {
+      replyMessage: `Here's your Google Calendar connection link:
+
+${authUrl}
+
+This will allow me to check your availability automatically when scheduling. If you'd rather not connect your calendar, just let me know and I'll ask for your availability manually instead.`,
+      reasoning: 'User explicitly requested calendar connection link',
+    }
+  }
+
+  // Get timezone information for the calling user
+  const callingUser = userMap.get(message.userId)
+  const callingUserTimezone = callingUser?.tz || 'UTC'
+
+  // Get channel information for descriptive display
+  const channelDescription = await getChannelDescription(message.channelId, userMap)
+
+  const userPrompt = `Your name in conversations: ${userMap.get(topic.botUserId)?.realName || 'Assistant'}
+
+Previous Messages in this Topic:
+${await organizeMessagesByChannelAndThread(previousMessages, callingUserTimezone)}
+
+Message To Reply To:
+From: ${userMap.get(message.userId)?.realName || 'Unknown User'} (Timezone: ${callingUser?.tz ? getShortTimezoneFromIANA(callingUserTimezone) : 'Unknown'})
+Text: "${replaceUserMentions(message.text, userMap)}"
+Channel: ${channelDescription}${
+  message.raw && typeof message.raw === 'object' && 'thread_ts' in message.raw && typeof message.raw.thread_ts === 'string'
+    ? `\nThread: [${formatTimestampWithTimezone(tsToDate(message.raw.thread_ts), callingUserTimezone)}]`
+    : ''
+}
+Timestamp: ${formatTimestampWithTimezone(message.timestamp, callingUserTimezone)}
+
+Based on the conversation history and current message, determine the next step in the scheduling workflow and generate the appropriate response.`
+
+  console.log(`User prompt: ${userPrompt}`)
+
+  try {
+    const runner = new Runner({ groupId: `topic-${topic.id}` })
+    const result = await runner.run(
+      agent,
+      userPrompt,
+      { context: { topic, userMap, callingUserTimezone } },
+    )
+    if (!result.finalOutput) {
+      throw new Error('No finalOutput generated')
+    }
+    return result.finalOutput
+  } catch (error) {
+    console.error('=== ERROR IN runConversationAgent ===')
+    console.error('Error type:', error instanceof Error ? error.constructor.name : typeof error)
+    console.error('Error message:', error instanceof Error ? error.message : String(error))
+    console.error('Stack trace:', error instanceof Error ? error.stack : 'No stack trace')
+    console.error('Full error object:', JSON.stringify(error, null, 2))
+    console.error('=================================')
+
+    // Return a safe default response
+    return {
+      replyMessage: 'I encountered an error processing the scheduling request.',
+      reasoning: `Error occurred: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,3 +1,13 @@
-export * from './analyze-topic-relevance'
-export * from './gen-fake-calendar'
-export * from './schedule-next-step'
+import type { WorkflowType } from '@shared/api-types'
+import type { ConversationAgent } from './conversation-utils'
+import { schedulingAgent } from './schedule-next-step'
+import { meetingPrepAgent } from './meeting-prep'
+
+export const workflowAgentMap = new Map<WorkflowType, ConversationAgent>([
+  ['scheduling', schedulingAgent],
+  ['meeting-prep', meetingPrepAgent],
+])
+
+export { analyzeTopicRelevance } from './analyze-topic-relevance'
+export { genFakeCalendar } from './gen-fake-calendar'
+export { runConversationAgent } from './conversation-utils'

--- a/src/agents/meeting-prep.ts
+++ b/src/agents/meeting-prep.ts
@@ -1,0 +1,174 @@
+import type { RunContext } from './agent-sdk'
+import type { ConversationContext } from './conversation-utils'
+import { ConversationAgent, ConversationRes, updateSummary, updateUserNames } from './conversation-utils'
+import { isCalendarConnected } from '../calendar-service'
+import { formatTimestampWithTimezone } from '../utils'
+import { getShortTimezoneFromIANA } from '@shared/utils'
+
+async function meetingPrepInstructions(runContext: RunContext<ConversationContext>) {
+  const mainPrompt = `You are a meeting preparation assistant that helps create meeting agendas. Your job is to gather updates and agenda items from participants, then synthesize them into a comprehensive meeting agenda.
+
+## Current Context
+You will receive:
+- The current message from a user
+- The topic information including all users currently involved
+- The topic summary describing what has been prepared so far
+
+## Your Task
+Based on the current state, determine what tools to call (if any) and generate the appropriate message(s) to users to gather updates and create the meeting agenda
+
+## Subtasks that need be handled
+1. Need to determine who should be involved
+  - Use the updateUserNames tool to specify the COMPLETE list of user names who should be involved
+  - IMPORTANT: Use the exact full names from the User Directory (e.g., "John Smith", not "John" or "Smith")
+  - The tool will replace the existing user list, not append to it
+  - Return replyMessage asking about missing participants or confirming who will be included
+
+2. Need to gather updates and proposed agenda items from participants
+  - Send messagesToUsers to each participant asking for:
+    * Their recent updates/progress on relevant work
+    * Any topics they'd like to discuss in the meeting
+    * Proposed agenda items they think should be included
+  - Track responses in the topic summary as you receive them
+  - Can gather from multiple users simultaneously (send individual DMs)
+  - Return replyMessage acknowledging the update collection process
+  - CRITICAL: If your replyMessage says you will reach out to others, you MUST include the corresponding messagesToUsers in the same response
+
+3. Need to synthesize updates and create draft agenda
+  - Once you have inputs from all participants (or a reasonable subset):
+    * Combine individual updates into a joint status summary
+    * Organize proposed agenda items by priority/theme
+    * Create a structured draft agenda with time allocations
+  - Update the topic summary with the synthesized information
+  - Return groupMessage with the draft agenda for review (sent to shared channel)
+
+4. Ready to circulate the draft agenda for feedback
+  - Return groupMessage with the draft agenda for review and feedback (sent to shared channel)
+  - Ask participants to review and suggest any changes or additions
+  - Return replyMessage with confirmation
+
+5. Agenda preparation is done
+  - If all users have reviewed the agenda and provided feedback, finalize the agenda
+  - Set markTopicInactive: true to indicate this topic should be marked inactive once the agenda is finalized
+
+- Miscellaneous actions needed
+  - Sometimes you need to ask for clarification, provide updates, or handle edge cases
+  - Return replyMessage with the appropriate response
+  - Optionally return messagesToUsers for private 1-1 clarifications (sent as DMs)
+  - Optionally return groupMessage for updates to all users in shared channel
+  - Can use updateUserNames tool if users need to be added/removed (use exact names from User Directory)
+
+## Important Guidelines
+- BE EXTREMELY CONCISE - keep all messages brief and to the point (1-2 sentences max unless listing agenda items)
+- Focus on ACTION - collect updates, synthesize agendas efficiently
+- When collecting updates/agenda items, ask specific questions to get actionable responses:
+  * What updates do you have on your current work?
+  * What topics need discussion in the meeting?
+  * What decisions need to be made?
+  * Any blockers or issues to address?
+- When synthesizing agenda, group related items
+- NEVER send messages that just confirm or acknowledge information - if someone shares their update, incorporate it and move forward
+- Skip pleasantries and acknowledgments - get straight to business
+- Respect privacy - don't share individual updates publicly until synthesized into joint summary
+- Use the updateSummary tool whenever new agenda information is gathered or synthesized
+- messagesToUsers always sends private 1-1 DMs; groupMessage always sends to a shared channel with all topic users
+- ALWAYS use exact full names from the User Directory when specifying updateUserNames or userNames in messagesToUsers
+- CRITICAL: Always execute promised actions immediately - if you say you'll reach out to users, include those messages in the current response
+- Never defer actions to a future response - everything mentioned in replyMessage must be actioned in the same response
+- AVOID REDUNDANT MESSAGES: Set replyMessage to empty string ("") when:
+  - You've already sent requests to other users and are just waiting for responses
+  - The user says "no response needed" or similar
+  - You have nothing new or meaningful to add
+  - You would just be acknowledging or confirming what was already said
+
+## CRITICAL TOOL USAGE
+You have access to TWO tools, but you can ONLY USE ONE per response:
+
+1. **updateUserNames**: Updates the list of users involved in the meeting
+   - USE THIS when you need to add/remove users from the topic
+   - Provide the COMPLETE list of user names (this replaces the existing list)
+   - Use exact names from the User Directory
+
+2. **updateSummary**: Updates the topic summary
+   - USE THIS whenever new information about agenda items is gathered
+   - Pass the updated summary with collected updates and agenda items
+   - Helps maintain context for the agenda preparation process
+
+## Response Format
+When calling a tool:
+- Do NOT return any JSON or text content
+- Simply call the tool and let it execute
+- The tool response will be handled automatically
+
+When NOT calling a tool, return ONLY a JSON object with these fields:
+{
+  "replyMessage": "Message text",  // Optional: Include to reply to the sent message
+  "markTopicInactive": true,      // Optional: Include to mark topic as inactive
+  "messagesToUsers": [             // Array of INDIVIDUAL 1-1 DM messages to send privately
+    {
+      "userNames": ["John Smith"],     // Send this message as individual DM to each user in list (MUST use exact names from User Directory)
+      "text": "Hi! What updates do you have for the meeting? Any topics you'd like to discuss?"
+    },
+    {
+      "userNames": ["Jane Doe", "Bob Wilson"],  // Each user gets the same message as a private DM (MUST use exact names from User Directory)
+      "text": "Please share your updates and any agenda items you'd like to add."
+    }
+  ],
+  "groupMessage": "Message text",  // Sends to SHARED CHANNEL with ALL users in topic's userIds list (finalize/complete)
+  "reasoning": "Brief explanation of the decision"  // REQUIRED: Always include reasoning
+}
+
+IMPORTANT:
+- When calling tools: Output NOTHING - just call the tool
+- When not calling tools: Return ONLY the JSON object above
+- Do not include any text before or after the JSON`
+
+  const { topic, userMap, callingUserTimezone } = runContext.context
+
+  const userMapAndTopicInfo = `
+${userMap && userMap.size > 0 ? `User Directory:
+${Array.from(userMap.entries())
+  .filter(([_userId, user]) => !user.isBot && user.realName)
+  .sort((a, b) => (a[1].realName!).localeCompare(b[1].realName!))
+  .map(([_userId, user]) => user.realName)
+  .join(', ')}
+
+` : ''}Current Topic:
+Summary: ${topic.summary}
+Users involved (with timezones and calendar status):
+${await Promise.all(topic.userIds.map(async (userId) => {
+  const user = userMap.get(userId)
+  const userName = user?.realName || 'Unknown User'
+  const tz = user?.tz
+  const userTzStr = tz ? `${userName} (${getShortTimezoneFromIANA(tz)})` : userName
+
+  try {
+    const isConnected = await isCalendarConnected(userId)
+    if (isConnected) {
+      return `  ${userTzStr}: Calendar is connected`
+    }
+  } catch (error) {
+    console.error(`Error checking calendar connection for ${userName}:`, error)
+  }
+  return `  ${userTzStr}: No calendar connected`
+})).then((results) => results.join('\n'))}
+Created: ${formatTimestampWithTimezone(topic.createdAt, callingUserTimezone)}
+Last updated: ${formatTimestampWithTimezone(topic.updatedAt, callingUserTimezone)}`
+
+  console.log(`User Map and Topic Info from system prompt: ${userMapAndTopicInfo}`)
+
+  return mainPrompt + userMapAndTopicInfo
+}
+
+export const meetingPrepAgent = new ConversationAgent({
+  name: 'meetingPrepAgent',
+  model: 'anthropic/claude-sonnet-4',
+  modelSettings: {
+    maxTokens: 1024,
+    temperature: 0.7,
+    parallelToolCalls: false, // Only allow one tool call at a time
+  },
+  tools: [updateUserNames, updateSummary],
+  outputType: ConversationRes,
+  instructions: meetingPrepInstructions,
+})

--- a/src/db/schema/main.ts
+++ b/src/db/schema/main.ts
@@ -8,9 +8,7 @@ import {
   unique,
 } from 'drizzle-orm/pg-core'
 import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
-import type { TopicUserContext, UserContext } from '@shared/api-types'
-
-export type WorkflowType = 'scheduling' | 'other'
+import type { WorkflowType, TopicUserContext, UserContext } from '@shared/api-types'
 
 export const topicTable = pgTable('topic', {
   id: uuid().primaryKey().defaultRandom(),

--- a/src/frontend/Home.tsx
+++ b/src/frontend/Home.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 import { api } from '@shared/api-client'
+import type { WorkflowType } from '@shared/api-types'
 
 interface Topic {
   id: string
   summary: string
-  workflowType: 'scheduling' | 'other'
+  workflowType: WorkflowType
   isActive: boolean
   createdAt: string
   updatedAt: string
@@ -82,13 +83,7 @@ function Home() {
               </h2>
 
               <div className="flex items-center gap-2 mb-3">
-                <span
-                  className={`inline-block px-2 py-1 text-xs font-medium rounded ${
-                    topic.workflowType === 'scheduling'
-                      ? 'bg-blue-100 text-blue-800'
-                      : 'bg-gray-100 text-gray-800'
-                  }`}
-                >
+                <span className="inline-block px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-800">
                   {topic.workflowType}
                 </span>
 

--- a/src/frontend/Topic.tsx
+++ b/src/frontend/Topic.tsx
@@ -421,13 +421,7 @@ function Topic() {
           <h1 className="text-xl font-bold">{topicData.topic.summary}</h1>
         </div>
         <div className="flex items-center gap-2 mb-2">
-          <span
-            className={`inline-block px-2 py-1 text-xs font-medium rounded ${
-              topicData.topic.workflowType === 'scheduling'
-                ? 'bg-blue-100 text-blue-800'
-                : 'bg-gray-100 text-gray-800'
-            }`}
-          >
+          <span className="inline-block px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-800">
             {topicData.topic.workflowType}
           </span>
           <span

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -7,6 +7,9 @@ import type { api } from './api-client'
 // Re-export database types for convenience
 export type { Topic, SlackMessage, SlackUser, SlackChannel, UserData }
 
+export const WorkflowType = z.enum(['scheduling', 'meeting-prep', 'other'])
+export type WorkflowType = z.infer<typeof WorkflowType>
+
 export const CalendarEvent = z.strictObject({
   start: z.string().describe('ISO timestamp for the start of the event'),
   end: z.string().describe('ISO timestamp for the end of the event'),


### PR DESCRIPTION
Summary:
Added a meetingPrepAgent which helps the group prepare for a meeting. As part of this:
- Moved the Context, Output, and Agent types from schedule-next-step.ts to conversation-utils.ts, and named them with the Conversation prefix to mark them for general use. Also moved updateUserNames and updateSummary tools, and userPrompt generation (the runConversationAgent function) into this file.
- Added a new meetingPrepAgent, which uses all these shared constructs for determining the next step of a conversation
- Update analyzeTopicRelevance to also look for messages that could be starting meeting-prep topics
- Update processSchedulingActions logic to select the conversation agent based on the topic's worklowType, and use that agent to respond to the topic

Test Plan:
In local flack, created scheduling and meeting-prep conversations and walked through them with the fake users