### PR TITLE
Pass slackClient to startAutoMessageCron

### DIFF
--- a/src/flack-server.ts
+++ b/src/flack-server.ts
@@ -266,5 +266,5 @@ export type AppType = typeof honoApp
 await upsertFakeUser({ id: BOT_USER_ID, realName: 'Pivotal', isBot: true })
 
 serve({ fetch: honoApp.fetch, port: PORT })
-startAutoMessageCron()
+startAutoMessageCron(mockSlackClient)
 console.log(`Flack webserver running on port ${PORT}...`)

--- a/src/slack-bot.ts
+++ b/src/slack-bot.ts
@@ -74,5 +74,5 @@ const honoApp = new Hono()
   })
 
 serve({ fetch: honoApp.fetch, port: PORT })
-startAutoMessageCron()
+startAutoMessageCron(slackApp.client)
 console.log(`Prod webserver running on port ${PORT}...`)


### PR DESCRIPTION
Summary:
Previously, the cron job would always use a mockSlackClient to send a message, which wouldn't work for prod. Now, it uses the real slack client on prod.

Test Plan:
Tested with pnpm run dev, scheduled an AutoMessage to myself