### PR TITLE
Use PV_LANGFUSE_BASE_URL for langfuse baseUrl

### DIFF
--- a/src/agents/agent-sdk.ts
+++ b/src/agents/agent-sdk.ts
@@ -24,7 +24,7 @@ const client = new OpenAI({
 const langfuse = new Langfuse({
   publicKey: process.env.PV_LANGFUSE_PUBLIC_KEY,
   secretKey: process.env.PV_LANGFUSE_SECRET_KEY,
-  baseUrl: 'https://us.cloud.langfuse.com',
+  baseUrl: process.env.PV_LANGFUSE_BASE_URL,
 })
 const tracingExporter = new LangfuseTracingExporter(langfuse)
 const traceProcessor = new BatchTraceProcessor(tracingExporter, { maxBatchSize: 1 })


### PR DESCRIPTION
Summary:
Add an env var to specify the langfuse base url, so we can use self-hosted langfuse

Test Plan:
Set up the keys and base url and saw the traces show up on our self-hosted langfuse instance