### PR TITLE
Split out topicState table from topic to track changes over time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ This is a Slack bot for AI-assisted scheduling with evaluation framework.
   '@stylistic/array-bracket-spacing': ['error', 'never'],
   '@stylistic/no-trailing-spaces': ['error'],
   '@stylistic/arrow-parens': ['error', 'always'],
-  '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+  '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_', 'varsIgnorePattern': '^_' }],
   '@typescript-eslint/consistent-type-imports': 'error',
 }
 ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,7 +44,7 @@ export default tseslint.config(
       '@stylistic/array-bracket-spacing': ['error', 'never'],
       '@stylistic/no-trailing-spaces': ['error'],
       '@stylistic/arrow-parens': ['error', 'always'],
-      '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+      '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_', 'varsIgnorePattern': '^_' }],
       '@typescript-eslint/consistent-type-imports': 'error',
     },
   },

--- a/src/agents/meeting-prep.ts
+++ b/src/agents/meeting-prep.ts
@@ -192,9 +192,9 @@ ${Array.from(userMap.entries())
   .join(', ')}
 
 ` : ''}Current Topic:
-Summary: ${topic.summary}
+Summary: ${topic.state.summary}
 Users involved (with timezones and calendar status):
-${await Promise.all(topic.userIds.map(async (userId) => {
+${await Promise.all(topic.state.userIds.map(async (userId: string) => {
   const user = userMap.get(userId)
   const userName = user?.realName || 'Unknown User'
   const tz = user?.tz
@@ -211,7 +211,7 @@ ${await Promise.all(topic.userIds.map(async (userId) => {
   return `  ${userTzStr}: No calendar connected`
 })).then((results) => results.join('\n'))}
 Created: ${formatTimestampWithTimezone(topic.createdAt, callingUserTimezone)}
-Last updated: ${formatTimestampWithTimezone(topic.updatedAt, callingUserTimezone)}`
+Last updated: ${formatTimestampWithTimezone(topic.state.createdAt, callingUserTimezone)}`
 
   console.log(`User Map and Topic Info from system prompt: ${userMapAndTopicInfo}`)
 

--- a/src/db/migrations/0020_add_topic_state_table.sql
+++ b/src/db/migrations/0020_add_topic_state_table.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "topic_state" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"topic_id" uuid NOT NULL,
+	"user_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"summary" text NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"per_user_context" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_by_message_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "topic_state" ADD CONSTRAINT "topic_state_topic_id_topic_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topic"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "topic_state" ADD CONSTRAINT "topic_state_created_by_message_id_slack_message_id_fk" FOREIGN KEY ("created_by_message_id") REFERENCES "public"."slack_message"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+-- Insert initial topic_state rows from existing topics
+INSERT INTO "topic_state" (topic_id, user_ids, summary, is_active, per_user_context, created_by_message_id, created_at)
+SELECT
+    t.id as topic_id,
+    t.user_ids,
+    t.summary,
+    t.is_active,
+    t.per_user_context,
+    (SELECT id FROM slack_message WHERE topic_id = t.id ORDER BY timestamp ASC LIMIT 1) as created_by_message_id,
+    t.updated_at as created_at
+FROM topic t
+WHERE EXISTS (SELECT 1 FROM slack_message WHERE topic_id = t.id);
+--> statement-breakpoint
+ALTER TABLE "topic" DROP COLUMN "user_ids";--> statement-breakpoint
+ALTER TABLE "topic" DROP COLUMN "summary";--> statement-breakpoint
+ALTER TABLE "topic" DROP COLUMN "is_active";--> statement-breakpoint
+ALTER TABLE "topic" DROP COLUMN "per_user_context";--> statement-breakpoint
+ALTER TABLE "topic" DROP COLUMN "updated_at";

--- a/src/db/migrations/meta/0020_snapshot.json
+++ b/src/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,797 @@
+{
+  "id": "4108b9c6-e731-42af-b6a2-7065ef115b8d",
+  "prevId": "2a080f9d-e366-4ff1-8305-6a9d9f372375",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_message": {
+      "name": "auto_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_send_time": {
+          "name": "next_send_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_schedule": {
+          "name": "recurrence_schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_new_topic": {
+          "name": "start_new_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deactivation_metadata": {
+          "name": "deactivation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auto_message_created_by_message_id_slack_message_id_fk": {
+          "name": "auto_message_created_by_message_id_slack_message_id_fk",
+          "tableFrom": "auto_message",
+          "tableTo": "slack_message",
+          "columnsFrom": [
+            "created_by_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel": {
+      "name": "slack_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_ids": {
+          "name": "user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_message": {
+      "name": "slack_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_ts": {
+          "name": "raw_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_message_id": {
+          "name": "auto_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_message_topic_id_topic_id_fk": {
+          "name": "slack_message_topic_id_topic_id_fk",
+          "tableFrom": "slack_message",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_message_auto_message_id_auto_message_id_fk": {
+          "name": "slack_message_auto_message_id_auto_message_id_fk",
+          "tableFrom": "slack_message",
+          "tableTo": "auto_message",
+          "columnsFrom": [
+            "auto_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user": {
+      "name": "slack_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_state": {
+      "name": "topic_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_ids": {
+          "name": "user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "per_user_context": {
+          "name": "per_user_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_state_topic_id_topic_id_fk": {
+          "name": "topic_state_topic_id_topic_id_fk",
+          "tableFrom": "topic_state",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "topic_state_created_by_message_id_slack_message_id_fk": {
+          "name": "topic_state_created_by_message_id_slack_message_id_fk",
+          "tableFrom": "topic_state",
+          "tableTo": "slack_message",
+          "columnsFrom": [
+            "created_by_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_data": {
+      "name": "user_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_data_slack_user_id_slack_user_id_fk": {
+          "name": "user_data_slack_user_id_slack_user_id_fk",
+          "tableFrom": "user_data",
+          "tableTo": "slack_user",
+          "columnsFrom": [
+            "slack_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_data_slack_user_id_unique": {
+          "name": "user_data_slack_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1756432705486,
       "tag": "0019_add_auto_message_table",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1757152963618,
+      "tag": "0020_add_topic_state_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/main.ts
+++ b/src/db/schema/main.ts
@@ -13,17 +13,25 @@ import type { WorkflowType, TopicUserContext, UserContext, AutoMessageDeactivati
 
 export const topicTable = pgTable('topic', {
   id: uuid().primaryKey().defaultRandom(),
-  userIds: jsonb().$type<string[]>().notNull().default([]),
   botUserId: text().notNull(),
-  summary: text().notNull(),
   workflowType: text().$type<WorkflowType>().notNull().default('other'),
-  isActive: boolean().notNull().default(true),
-  perUserContext: jsonb().$type<Record<string, TopicUserContext>>().notNull().default({}),
   createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp({ withTimezone: true }).notNull().defaultNow().$onUpdate(() => new Date()),
 })
 export type TopicInsert = InferInsertModel<typeof topicTable>
 export type Topic = InferSelectModel<typeof topicTable>
+
+export const topicStateTable = pgTable('topic_state', {
+  id: uuid().primaryKey().defaultRandom(),
+  topicId: uuid().notNull().references(() => topicTable.id),
+  userIds: jsonb().$type<string[]>().notNull().default([]),
+  summary: text().notNull(),
+  isActive: boolean().notNull().default(true),
+  perUserContext: jsonb().$type<Record<string, TopicUserContext>>().notNull().default({}),
+  createdByMessageId: uuid().notNull().references(() => slackMessageTable.id),
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+})
+export type TopicStateInsert = InferInsertModel<typeof topicStateTable>
+export type TopicState = InferSelectModel<typeof topicStateTable>
 
 export const slackMessageTable = pgTable('slack_message', {
   id: uuid().primaryKey().defaultRandom(),

--- a/src/frontend/Home.tsx
+++ b/src/frontend/Home.tsx
@@ -1,20 +1,11 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router'
 import { local_api } from '@shared/api-client'
-import type { WorkflowType } from '@shared/api-types'
-
-interface Topic {
-  id: string
-  summary: string
-  workflowType: WorkflowType
-  isActive: boolean
-  createdAt: string
-  updatedAt: string
-  userIds: string[]
-}
+import type { TopicWithState } from '@shared/api-types'
+import { unserializeTopicWithState } from '@shared/api-types'
 
 function Home() {
-  const [topics, setTopics] = useState<Topic[]>([])
+  const [topics, setTopics] = useState<TopicWithState[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -26,7 +17,8 @@ function Home() {
           throw new Error('Failed to fetch topics')
         }
         const data = await response.json()
-        setTopics(data.topics)
+        const topicsWithDates = data.topics.map(unserializeTopicWithState)
+        setTopics(topicsWithDates)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred')
       } finally {
@@ -79,7 +71,7 @@ function Home() {
               className="block p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-gray-200 w-full max-w-2xl"
             >
               <h2 className="text-xl font-semibold mb-2 text-gray-800">
-                {topic.summary}
+                {topic.state.summary}
               </h2>
 
               <div className="flex items-center gap-2 mb-3">
@@ -89,17 +81,17 @@ function Home() {
 
                 <span
                   className={`inline-block px-2 py-1 text-xs font-medium rounded ${
-                    topic.isActive
+                    topic.state.isActive
                       ? 'bg-green-100 text-green-800'
                       : 'bg-red-100 text-red-800'
                   }`}
                 >
-                  {topic.isActive ? 'Active' : 'Inactive'}
+                  {topic.state.isActive ? 'Active' : 'Inactive'}
                 </span>
               </div>
 
               <div className="text-sm text-gray-600">
-                <div>Users: {topic.userIds.length}</div>
+                <div>Users: {topic.state.userIds.length}</div>
                 <div>Created: {new Date(topic.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</div>
               </div>
             </Link>

--- a/src/frontend/Topic.tsx
+++ b/src/frontend/Topic.tsx
@@ -418,7 +418,7 @@ function Topic() {
           <Link to="/" className="text-blue-600 hover:underline text-sm">
             ← Back to Topics
           </Link>
-          <h1 className="text-xl font-bold">{topicData.topic.summary}</h1>
+          <h1 className="text-xl font-bold">{topicData.topic.state.summary}</h1>
         </div>
         <div className="flex items-center gap-2 mb-2">
           <span className="inline-block px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-800">
@@ -426,15 +426,15 @@ function Topic() {
           </span>
           <span
             className={`inline-block px-2 py-1 text-xs font-medium rounded ${
-              topicData.topic.isActive
+              topicData.topic.state.isActive
                 ? 'bg-green-100 text-green-800'
                 : 'bg-red-100 text-red-800'
             }`}
           >
-            {topicData.topic.isActive ? 'Active' : 'Inactive'}
+            {topicData.topic.state.isActive ? 'Active' : 'Inactive'}
           </span>
           <span className="text-sm text-gray-600">
-            Updated: {new Date(topicData.topic.updatedAt).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', second: '2-digit' })}
+            Updated: {new Date(topicData.topic.state.createdAt).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit', second: '2-digit' })}
           </span>
           {sortedMessages.length > 0 && timelinePosition !== null && (
             <span className="text-sm text-gray-600">
@@ -456,7 +456,7 @@ function Topic() {
               const userId = isDM ? getCurrentUserId(channel.channelId) : null
               const user = userId ? topicData.users.find((u) => u.id === userId) : null
               const userData = userId ? topicData.userData?.find((ud) => ud.slackUserId === userId) : null
-              const topicUserContext = userId ? topicData.topic.perUserContext[userId] : null
+              const topicUserContext = userId ? topicData.topic.state.perUserContext[userId] : null
 
               return (
                 <div

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -1,11 +1,15 @@
 import type { InferResponseType } from 'hono/client'
 import { z } from 'zod'
 
-import type { Topic, SlackMessage, SlackUser, SlackChannel, UserData } from '../db/schema/main'
+import type { Topic, TopicState, SlackMessage, SlackUser, SlackChannel, UserData } from '../db/schema/main'
 import type { local_api } from './api-client'
 
 // Re-export database types for convenience
-export type { Topic, SlackMessage, SlackUser, SlackChannel, UserData }
+export type { SlackMessage, SlackUser, SlackChannel, UserData }
+
+export type TopicWithState = Topic & {
+  state: TopicState
+}
 
 export const WorkflowType = z.enum(['scheduling', 'meeting-prep', 'other'])
 export type WorkflowType = z.infer<typeof WorkflowType>
@@ -52,22 +56,30 @@ export interface AutoMessageDeactivation {
 }
 
 export interface TopicData {
-  topic: Topic
+  topic: TopicWithState
   messages: SlackMessage[]
   users: SlackUser[]
   userData?: UserData[]
   channels?: SlackChannel[]
 }
 
-export type TopicRes = InferResponseType<typeof local_api.topics[':topicId']['$get'], 200>
+type TopicWithStateRes = InferResponseType<typeof local_api.topics['$get'], 200>['topics'][number]
+export type TopicDataRes = InferResponseType<typeof local_api.topics[':topicId']['$get'], 200>
 
-export function unserializeTopicData(topicRes: TopicRes): TopicData {
+export function unserializeTopicWithState(topic: TopicWithStateRes): TopicWithState {
   return {
-    topic: {
-      ...topicRes.topic,
-      createdAt: new Date(topicRes.topic.createdAt),
-      updatedAt: new Date(topicRes.topic.updatedAt),
+    ...topic,
+    createdAt: new Date(topic.createdAt),
+    state: {
+      ...topic.state,
+      createdAt: new Date(topic.state.createdAt),
     },
+  }
+}
+
+export function unserializeTopicData(topicRes: TopicDataRes): TopicData {
+  return {
+    topic: unserializeTopicWithState(topicRes.topic),
     messages: topicRes.messages.map((message) => ({
       ...message,
       timestamp: new Date(message.timestamp),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
-import { eq, inArray, and, sql, lt, isNotNull } from 'drizzle-orm'
+import { eq, desc, inArray, and, sql, lt, isNotNull, max } from 'drizzle-orm'
 import { z } from 'zod'
 import { CronJob } from 'cron'
 import { RRuleTemporal } from 'rrule-temporal'
@@ -16,28 +16,112 @@ import type {
   SlackUserInsert,
   SlackChannelInsert,
   UserDataInsert,
-  AutoMessage } from './db/schema/main'
+  AutoMessage,
+  TopicStateInsert,
+} from './db/schema/main'
 import {
   slackMessageTable,
   topicTable,
+  topicStateTable,
   slackUserTable,
   slackChannelTable,
   userDataTable,
   autoMessageTable,
 } from './db/schema/main'
-import type { TopicData, TopicRes } from '@shared/api-types'
+import type { TopicData, TopicDataRes } from '@shared/api-types'
 import { unserializeTopicData } from '@shared/api-types'
 import { getShortTimezoneFromIANA } from '@shared/utils'
 import type { SlackAPIMessage } from './slack-message-handler'
 import { handleSlackMessage } from './slack-message-handler'
 import { getOrCreateChannelForUsers } from './local-helpers'
-import type { AutoMessageDeactivation } from '@shared/api-types'
+import type { AutoMessageDeactivation, TopicWithState } from '@shared/api-types'
 import type { WebClient } from '@slack/web-api'
 
 export function tsToDate(ts: string): Date {
   return new Date(Number(ts) * 1000)
 }
 
+export async function getTopicWithState(topicId: string): Promise<TopicWithState> {
+  // Get the topic along with its most recent state
+  const [row] = await db
+    .select()
+    .from(topicTable)
+    .innerJoin(topicStateTable, eq(topicTable.id, topicStateTable.topicId))
+    .where(eq(topicTable.id, topicId))
+    .orderBy(desc(topicStateTable.createdAt))
+    .limit(1)
+
+  if (!row) {
+    throw new Error(`Topic with id ${topicId} not found`)
+  }
+
+  return {
+    ...row.topic,
+    state: row.topic_state,
+  }
+}
+
+export async function getTopics(botUserId: string | null = null, onlyActive: boolean = false): Promise<TopicWithState[]> {
+  const filters = []
+  if (botUserId) {
+    filters.push(eq(topicTable.botUserId, botUserId))
+  }
+  if (onlyActive) {
+    filters.push(eq(topicStateTable.isActive, true))
+  }
+
+  const latestStateSubquery = db
+    .select({ maxDate: max(topicStateTable.createdAt) })
+    .from(topicStateTable)
+    .where(eq(topicStateTable.topicId, topicTable.id))
+
+  const rows = await db
+    .select()
+    .from(topicTable)
+    .innerJoin(
+      topicStateTable,
+      and(
+        eq(topicTable.id, topicStateTable.topicId),
+        eq(topicStateTable.createdAt, latestStateSubquery),
+      ),
+    )
+    .where(and(...filters))
+    .orderBy(desc(topicStateTable.createdAt))
+
+  return rows.map((row) => ({
+    ...row.topic,
+    state: row.topic_state,
+  }))
+}
+
+export async function updateTopicState(
+  topic: TopicWithState,
+  updates: Partial<Omit<TopicStateInsert, 'id' | 'topicId' | 'createdByMessageId' | 'createdAt'>>,
+  messageId: string,
+): Promise<TopicWithState> {
+  // Don't pass the current state id or createdAt when creating the new state
+  const {
+    id: _id,
+    createdAt: _createdAt,
+    ...currentState
+  } = topic.state
+
+  // Create new topic state by merging current state with updates
+  const [newTopicState] = await db
+    .insert(topicStateTable)
+    .values({
+      ...currentState,
+      ...updates,
+      createdByMessageId: messageId,
+    })
+    .returning()
+
+  // Return the updated topic with new state
+  return {
+    ...topic,
+    state: newTopicState,
+  }
+}
 
 export const GetTopicReq = z.strictObject({
   lastMessageId: z.string().optional(),
@@ -49,15 +133,7 @@ export type GetTopicReq = z.infer<typeof GetTopicReq>
 export async function dumpTopic(topicId: string, options: GetTopicReq = {}): Promise<TopicData> {
   const { lastMessageId, visibleToUserId, beforeRawTs } = options
 
-  const [topic] = await db
-    .select()
-    .from(topicTable)
-    .where(eq(topicTable.id, topicId))
-    .limit(1)
-
-  if (!topic) {
-    throw new Error(`Topic with id ${topicId} not found`)
-  }
+  const topic = await getTopicWithState(topicId)
 
   // Build the messages query with optional channel filtering
   let messages: SlackMessage[]
@@ -106,19 +182,19 @@ export async function dumpTopic(topicId: string, options: GetTopicReq = {}): Pro
   }
 
   // Fetch users that are referenced in the topic
-  const users = topic.userIds.length > 0
+  const users = topic.state.userIds.length > 0
     ? await db
         .select()
         .from(slackUserTable)
-        .where(inArray(slackUserTable.id, topic.userIds))
+        .where(inArray(slackUserTable.id, topic.state.userIds))
     : []
 
   // Fetch userData for users referenced in the topic
-  const userData = topic.userIds.length > 0
+  const userData = topic.state.userIds.length > 0
     ? await db
         .select()
         .from(userDataTable)
-        .where(inArray(userDataTable.slackUserId, topic.userIds))
+        .where(inArray(userDataTable.slackUserId, topic.state.userIds))
     : []
 
   // Fetch unique channel IDs from messages
@@ -131,7 +207,7 @@ export async function dumpTopic(topicId: string, options: GetTopicReq = {}): Pro
     : []
 
   const result: TopicData = {
-    topic: topic,
+    topic,
     messages,
     users,
     userData,
@@ -143,10 +219,10 @@ export async function dumpTopic(topicId: string, options: GetTopicReq = {}): Pro
 
 export async function loadTopics(jsonData: string): Promise<{ topicIds: string[] }> {
   // Parse string input if needed
-  const parsedData = JSON.parse(jsonData) as TopicRes | TopicRes[]
+  const parsedData = JSON.parse(jsonData) as TopicDataRes | TopicDataRes[]
 
   // Normalize to array with Date objects
-  const topicReqsArray: TopicRes[] = Array.isArray(parsedData) ? parsedData : [parsedData]
+  const topicReqsArray: TopicDataRes[] = Array.isArray(parsedData) ? parsedData : [parsedData]
   const topicsArray: TopicData[] = topicReqsArray.map((topicRes) => unserializeTopicData(topicRes))
 
   const topicIds: string[] = []


### PR DESCRIPTION
Summary:
We'd like to track when a topic's summary, user ids, etc change so that we can actually replay a conversation step by step, and replicate the exact behavior of the bot at any given point in time (for now, we're not worried that the user contexts can also change over time -- the topic changes more often and is more critical to track).

This allows point-in-time testing for topic routing and conversation agents, which is becoming increasingly important as our app grows in scope and usage and we are running into more edge cases.

To do this, we moved many of the fields from Topic to a new TopicState table, which we now append to rather than updating. This requires a migration, as well as substantial changes to the slack-message-handler logic. There is also a widespread change to the codebase to use the TopicWithState type rather than the Topic type everywhere.

Test Plan:
Ran the migration and server locally, and made sure everything went as expected and is still working