### PR TITLE
In showUserCalendar tool, say if the user has no calendar connected

### DIFF
--- a/src/agents/conversation-utils.ts
+++ b/src/agents/conversation-utils.ts
@@ -260,7 +260,9 @@ export const showUserCalendar = tool({
       }
     }
 
-    if (!calendarEvents || calendarEvents.length === 0) {
+    if (calendarEvents === null) {
+      return `${userName} does not have their calendar connected`
+    } else if (calendarEvents.length === 0) {
       return `No calendar events found for ${userName} between ${formatTimestampWithTimezone(startTimeDate, userTz)} and ${formatTimestampWithTimezone(endTimeDate, userTz)}`
     }
 


### PR DESCRIPTION
Summary:
Update the tool to handle the case where it is called but the user's calendar is actually not connected, for example if their access token expired.

Test Plan:
None