### PR TITLE
Fix google redirect uri

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import db from './db/engine'
 import { betterAuthSchema } from './db/schema/auth'
 
-const baseURL = (
+export const baseURL = (
   process.env.PV_NODE_ENV === 'local' ?
   'https://localhost:5173' :
   process.env.PV_BASE_URL || 'https://localhost:3009'

--- a/src/calendar-service.ts
+++ b/src/calendar-service.ts
@@ -12,6 +12,7 @@ import { mergeCalendarWithOverrides } from '@shared/utils'
 import { genFakeCalendar } from './agents'
 import { processSchedulingActions } from './slack-message-handler'
 import { getTopicWithState, updateTopicState } from './utils'
+import { baseURL } from './auth'
 
 export interface GoogleAuthTokenResponse {
   access_token: string
@@ -21,8 +22,7 @@ export interface GoogleAuthTokenResponse {
   token_type: string
 }
 
-const API_BASE_URL = process.env.PV_BASE_URL || 'http://localhost:3001'
-const GOOGLE_AUTH_REDIRECT_URI = `${API_BASE_URL}/auth/google/callback`
+const GOOGLE_AUTH_REDIRECT_URI = `${baseURL}/auth/google/callback`
 
 /**
  * Get stored user context

--- a/src/shared/api-client.ts
+++ b/src/shared/api-client.ts
@@ -1,10 +1,10 @@
 import { hc } from 'hono/client'
 import type { AppType } from '../server'
 
-// Use relative URL when running through Vite to use proxy
-// Use direct URL when running outside of Vite (e.g., in server or flack-eval)
-const isViteDev = import.meta.env ?? false
-const API_BASE_URL = isViteDev ? '/' : 'http://localhost:3001'
+// Use relative URL when running frontend code
+// Use direct URL to local server when running outside frontend code (e.g. in evals)
+const isFrontend = import.meta.env ?? false
+const API_BASE_URL = isFrontend ? '/' : 'http://localhost:3001'
 
 const appType = hc<AppType>(API_BASE_URL)
 export const { api, local_api } = appType

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import { readFileSync } from 'fs'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     react(),
     tailwindcss(),
@@ -16,13 +16,15 @@ export default defineConfig({
     },
   },
   server: {
-    https: {
-      cert: readFileSync(path.resolve(__dirname, '.cert/cert.pem')),
-      key: readFileSync(path.resolve(__dirname, '.cert/key.pem')),
-    },
+    ...(command === 'serve' && {
+      https: {
+        cert: readFileSync(path.resolve(__dirname, '.cert/cert.pem')),
+        key: readFileSync(path.resolve(__dirname, '.cert/key.pem')),
+      },
+    }),
     proxy: {
       '/local_api': 'http://localhost:3001',
       '/api': 'http://localhost:3001',
     },
   },
-})
+}))


### PR DESCRIPTION
Summary:
The google calendar connection redirect uri was hardcoded to localhost:3001, which was failing for 'pnpm run dev'. It's now been fixed to take the baseURL directly from auth.ts.

I also fixed the vite config so that it doesn't try to access the local cert files when 'vite build' is being run, which prevents it from erroring out on the prod server.

Test Plan:
Tested with 'pnpm run dev' locally, and was able to connect my calendar and access the 'Calendar connected successfully!' screen