### PR TITLE
Fix langfuse span hierarchy

### DIFF
--- a/src/agents/langfuse-tracing-exporter.ts
+++ b/src/agents/langfuse-tracing-exporter.ts
@@ -20,7 +20,42 @@ import type {
   GenerationSpanData,
 } from '@openai/agents-core/tracing/spans'
 
-const PLACEHOLDER_NAME = 'trace'
+type LangfuseGenerationParams = {
+  id: string
+  name: string
+  startTime: Date | null
+  endTime: Date | null
+  model: string | undefined
+  modelParameters: Record<string, string | number | boolean | string[] | null> | null | undefined,
+  input: unknown
+  output: unknown
+  usage?: {
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+  }
+  metadata: {
+    rawData: Omit<GenerationSpanData, 'input' | 'output'>
+    error: unknown
+  }
+  level: 'ERROR' | 'DEFAULT'
+  statusMessage: string | undefined
+}
+
+type LangfuseSpanParams = {
+  id: string
+  name: string
+  startTime: Date | null
+  endTime: Date | null
+  input: unknown
+  output: unknown
+  metadata: {
+    rawData: Omit<SpanData, 'input' | 'output'>
+    error: unknown
+  }
+  level: 'ERROR' | 'DEFAULT'
+  statusMessage: string | undefined
+}
 
 /**
  * TracingExporter implementation that sends OpenAI agent traces to Langfuse
@@ -29,10 +64,13 @@ export class LangfuseTracingExporter implements TracingExporter {
   private langfuse: Langfuse
   private enableDebugLogging: boolean
 
-  // Maps to track relationships between OpenAI and Langfuse objects
+  // Maps to store traces, so that children spans can find them later
   private traceMap: Map<string, LangfuseTraceClient> = new Map()
-  private traceNameMap: Map<string, string> = new Map()
-  private spanMap: Map<string, LangfuseSpanClient | LangfuseGenerationClient> = new Map()
+
+  // Since spans are created as the nested function calls resolve, they are received
+  // before their parent spans. Therefore we have to collect them and wait for the
+  // parent span to be created before exporting them as children
+  private spanIdToChildrenParams: Map<string, (LangfuseGenerationParams | LangfuseSpanParams)[]> = new Map()
 
   constructor(langfuse: Langfuse, enableDebugLogging: boolean = false) {
     this.langfuse = langfuse
@@ -53,7 +91,7 @@ export class LangfuseTracingExporter implements TracingExporter {
         if (item.type === 'trace') {
           this.exportTrace(item)
         } else if (item.type === 'trace.span') {
-          this.exportSpan(item)
+          this.createSpan(item)
         }
       }
 
@@ -76,14 +114,13 @@ export class LangfuseTracingExporter implements TracingExporter {
     // Create Langfuse trace
     const langfuseTrace = this.langfuse.trace({
       id: trace.traceId,
-      name: PLACEHOLDER_NAME,
+      name: 'trace',
       sessionId: trace.groupId,
       metadata: trace.metadata,
     })
 
     // Store mapping
     this.traceMap.set(trace.traceId, langfuseTrace)
-    this.traceNameMap.set(trace.traceId, PLACEHOLDER_NAME)
 
     if (this.enableDebugLogging) {
       console.log(`[Langfuse] Created trace: ${trace.traceId}`)
@@ -91,33 +128,20 @@ export class LangfuseTracingExporter implements TracingExporter {
   }
 
   /**
-   * Export a span to Langfuse
+   * Create a span for export to Langfuse
    */
-  private exportSpan(span: Span<SpanData>) {
+  private createSpan(span: Span<SpanData>) {
     // Get parent trace or span
     const parentTrace = this.traceMap.get(span.traceId)
-    const parentSpan = span.parentId ? this.spanMap.get(span.parentId) : undefined
 
-    // Create a default trace if none exists
-    if (!parentTrace && !parentSpan) {
+    // Create a default trace if none exists, which should never happen
+    if (!parentTrace) {
       const defaultTraceName = 'auto-created-trace'
       const defaultTrace = this.langfuse.trace({
         id: span.traceId,
         name: defaultTraceName,
       })
       this.traceMap.set(span.traceId, defaultTrace)
-      this.traceNameMap.set(span.traceId, defaultTraceName)
-    }
-
-    // Update placeholder trace name with name of first agent span
-    if (
-      parentTrace &&
-      this.traceNameMap.get(span.traceId) === PLACEHOLDER_NAME &&
-      span.spanData.type === 'agent'
-    ) {
-      const newName = `trace-${span.spanData.name}`
-      parentTrace.update({ name: newName })
-      this.traceNameMap.set(span.traceId, newName)
     }
 
     // Determine if this should be a generation or regular span
@@ -132,8 +156,6 @@ export class LangfuseTracingExporter implements TracingExporter {
    * Create a Langfuse generation for LLM spans
    */
   private createLangfuseGeneration(span: Span<GenerationSpanData>) {
-    const parent = this.traceMap.get(span.traceId)
-    if (!parent) throw new Error(`No trace found for span.traceId: ${span.traceId}`)
     const data = span.spanData
 
     // Try to get usage from data.output[0].usage
@@ -151,7 +173,7 @@ export class LangfuseTracingExporter implements TracingExporter {
     delete dataWithoutIO.input
     delete dataWithoutIO.output
 
-    const generation = parent.generation({
+    const generationParams: LangfuseGenerationParams = {
       id: span.spanId,
       name: data.type,
       startTime: span.startedAt ? new Date(span.startedAt) : null,
@@ -171,9 +193,19 @@ export class LangfuseTracingExporter implements TracingExporter {
       },
       level: span.error ? 'ERROR' : 'DEFAULT',
       statusMessage: span.error?.message,
-    })
+    }
 
-    this.spanMap.set(span.spanId, generation)
+    if (span.parentId) {
+      // If there's a parentId, this is a child of a span, so queue to be exported later
+      const parentChildren = this.spanIdToChildrenParams.get(span.parentId) || []
+      parentChildren.push(generationParams)
+      this.spanIdToChildrenParams.set(span.parentId, parentChildren)
+    } else {
+      // If no parentId, this is the direct child of the trace, so export immediately
+      const parent = this.traceMap.get(span.traceId)
+      if (!parent) throw new Error(`No trace found for span.traceId: ${span.traceId}`)
+      this.exportSpanAndChildren(generationParams, parent)
+    }
 
     if (this.enableDebugLogging) {
       console.log(`[Langfuse] Created generation: ${span.spanId}`)
@@ -184,18 +216,17 @@ export class LangfuseTracingExporter implements TracingExporter {
    * Create a Langfuse span for non-LLM spans
    */
   private createLangfuseSpan(span: Span<SpanData>) {
-    const parent = this.traceMap.get(span.traceId)
-    if (!parent) throw new Error(`No trace found for span.traceId: ${span.traceId}`)
     const data = span.spanData
+    const nameSuffix = 'name' in data ? '-' + data.name : ''
 
     // Create dataWithoutIO for metadata
     const dataWithoutIO = { ...data }
     if ('input' in dataWithoutIO) delete dataWithoutIO.input
     if ('output' in dataWithoutIO) delete dataWithoutIO.output
 
-    const langfuseSpan = parent.span({
+    const spanParams: LangfuseSpanParams = {
       id: span.spanId,
-      name: `${data.type}${'name' in data ? '-' + data.name : ''}`,
+      name: `${data.type}${nameSuffix}`,
       startTime: span.startedAt ? new Date(span.startedAt) : null,
       endTime: span.endedAt ? new Date(span.endedAt) : null,
       input: 'input' in data ? data.input : null,
@@ -206,12 +237,44 @@ export class LangfuseTracingExporter implements TracingExporter {
       },
       level: span.error ? 'ERROR' : 'DEFAULT',
       statusMessage: span.error?.message,
-    })
+    }
 
-    this.spanMap.set(span.spanId, langfuseSpan)
+    if (span.parentId) {
+      // If there's a parentId, this is a child of a span, so queue to be exported later
+      const parentChildren = this.spanIdToChildrenParams.get(span.parentId) || []
+      parentChildren.push(spanParams)
+      this.spanIdToChildrenParams.set(span.parentId, parentChildren)
+    } else {
+      // If no parentId, this is the direct child of the trace, so export immediately
+      const parent = this.traceMap.get(span.traceId)
+      if (!parent) throw new Error(`No trace found for span.traceId: ${span.traceId}`)
+      // Update the trace name to match its direct child span, for readability in Tracing table
+      parent.update({ name: `trace${nameSuffix}` })
+      this.exportSpanAndChildren(spanParams, parent)
+    }
 
     if (this.enableDebugLogging) {
       console.log(`[Langfuse] Created span: ${span.spanId} (${data.type})`)
     }
+  }
+
+  /**
+   * Actually export the span and all of its accumulated children
+   */
+  private exportSpanAndChildren(
+    spanParams: LangfuseGenerationParams | LangfuseSpanParams,
+    parent: LangfuseTraceClient | LangfuseSpanClient | LangfuseGenerationClient,
+  ) {
+    const span = (
+      spanParams.name === 'generation' ?
+      parent.generation(spanParams) :
+      parent.span(spanParams)
+    )
+
+    const childrenParams = this.spanIdToChildrenParams.get(spanParams.id) || []
+    for (const childParams of childrenParams) {
+      this.exportSpanAndChildren(childParams, span)
+    }
+    this.spanIdToChildrenParams.delete(spanParams.id)
   }
 }


### PR DESCRIPTION
Summary:
Updated our custom tracing exporter that translates openai sdk spans to langfuse, in order to properly track the span parent relationships. Now we see the correct nested hierarchy of agent + tool calls in langfuse.

Test Plan:
Tested locally