### PR TITLE
Add organizations, tied to slack teams

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,11 +1,15 @@
-import { betterAuth } from 'better-auth'
+import { betterAuth, generateId } from 'better-auth'
 import { createAuthEndpoint, createAuthMiddleware, getSessionFromCtx, APIError } from 'better-auth/api'
 import type { Account } from 'better-auth/types'
+import { organization } from 'better-auth/plugins'
 import type { BetterAuthPlugin } from 'better-auth/plugins'
+import type { SlackProfile } from 'better-auth/social-providers'
+import { decryptOAuthToken } from 'better-auth/oauth2'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { createRandomStringGenerator } from '@better-auth/utils/random'
+import { eq, and } from 'drizzle-orm'
 import db from './db/engine'
-import { betterAuthSchema } from './db/schema/auth'
+import { betterAuthSchema, organizationTable, memberTable } from './db/schema/auth'
 
 export const baseURL = (
   process.env.PV_NODE_ENV === 'local' ?
@@ -18,6 +22,132 @@ if (process.env.PV_NODE_ENV === 'prod' && !process.env.PV_BETTER_AUTH_SECRET) {
 }
 
 const generateRandomString = createRandomStringGenerator('a-z', '0-9', 'A-Z', '-_')
+
+export function slackTeamPlugin() {
+  return {
+    id: 'slack-team-plugin',
+    // After slack login, assign the user to an organization based on the slack team id
+    hooks: {
+      after: [{
+        matcher: (c) => {
+          return c.path === '/callback/:id' && c.params?.id === 'slack'
+        },
+        handler: createAuthMiddleware(async (c) => {
+          const session = c.context.newSession
+          if (!session) {
+            c.context.logger.error('No new session found')
+            return
+          }
+          const userId = session.user.id
+          const sessionToken = session.session.token
+
+          const slackProvider = c.context.socialProviders.find((p) => p.id === 'slack')
+          if (!slackProvider) {
+            c.context.logger.error('No Slack provider found')
+            await c.context.internalAdapter.deleteSession(sessionToken)
+            return
+          }
+
+          const accounts = await c.context.internalAdapter.findAccounts(userId)
+          const slackAccount = accounts.find((account) => account.providerId === 'slack')
+          if (!slackAccount) {
+            c.context.logger.error('No Slack account found for user')
+            await c.context.internalAdapter.deleteSession(sessionToken)
+            return
+          }
+
+          const accessToken = await decryptOAuthToken(slackAccount.accessToken || '', c.context)
+          const userInfo = await slackProvider.getUserInfo({ accessToken })
+          if (!userInfo) {
+            c.context.logger.error('No Slack userInfo found')
+            await c.context.internalAdapter.deleteSession(sessionToken)
+            return
+          }
+
+          const slackData = userInfo.data as SlackProfile
+          const slackTeamId = slackData['https://slack.com/team_id']
+          const slackTeamName = slackData['https://slack.com/team_name']
+          const slackTeamDomain = slackData['https://slack.com/team_domain']
+
+          try {
+            // Query for existing organization with this Slack team ID
+            const [existingOrg] = await db.select()
+              .from(organizationTable)
+              .where(eq(organizationTable.slackTeamId, slackTeamId))
+              .limit(1)
+
+            if (!existingOrg) {
+              // Create new organization using db
+              const [newOrg] = await db.insert(organizationTable)
+                .values({
+                  id: generateId(),
+                  name: slackTeamName,
+                  slug: slackTeamDomain,
+                  slackTeamId,
+                })
+                .returning()
+
+              // Add member to the new organization
+              await auth.api.addMember({
+                body: {
+                  userId,
+                  organizationId: newOrg.id,
+                  role: 'member',
+                },
+              })
+
+              c.context.logger.info(`Created organization ${newOrg.id} for Slack team ${slackTeamId}`)
+            } else {
+              // Check if user is already a member
+              const [existingMember] = await db.select()
+                .from(memberTable)
+                .where(and(
+                  eq(memberTable.organizationId, existingOrg.id),
+                  eq(memberTable.userId, userId),
+                ))
+                .limit(1)
+
+              if (!existingMember) {
+                // Remove user from any existing organizations
+                const removedOrgs = await db
+                  .delete(memberTable)
+                  .where(eq(memberTable.userId, userId))
+                  .returning()
+
+                for (const membership of removedOrgs) {
+                  c.context.logger.info(`Removed user ${userId} from organization ${membership.organizationId}`)
+                }
+
+                // Add to the new organization
+                await auth.api.addMember({
+                  body: {
+                    userId,
+                    organizationId: existingOrg.id,
+                    role: 'member',
+                  },
+                })
+
+                c.context.logger.info(`Added user ${userId} to organization ${existingOrg.id}`)
+              }
+            }
+          } catch (error) {
+            c.context.logger.error('Failed to create or join organization', error)
+            await c.context.internalAdapter.deleteSession(sessionToken)
+            return
+          }
+        }),
+      }],
+    },
+
+    schema: {
+      organization: {
+        fields: {
+          slackTeamId: { type: 'string', required: true, unique: true },
+        },
+      },
+    },
+  } satisfies BetterAuthPlugin
+}
 
 export function githubAppInstallationPlugin(appName: string) {
   return {
@@ -133,6 +263,11 @@ export const auth = betterAuth({
     schema: betterAuthSchema,
   }),
   plugins: [
+    organization({
+      allowUserToCreateOrganization: false,
+      organizationLimit: 1,
+    }),
+    slackTeamPlugin(),
     githubAppInstallationPlugin(process.env.PV_GITHUB_APP_NAME!),
   ],
   socialProviders: {
@@ -159,6 +294,7 @@ export const auth = betterAuth({
     encryptOAuthTokens: true,
     accountLinking: {
       enabled: true,
+      allowUnlinkingAll: true,
       trustedProviders: ['slack', 'github', 'google'],
     },
   },

--- a/src/db/migrations/0025_add_organization_member_and_invitation_tables.sql
+++ b/src/db/migrations/0025_add_organization_member_and_invitation_tables.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "invitation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"email" text NOT NULL,
+	"role" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"inviter_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "member" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text DEFAULT 'member' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organization" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"slug" text,
+	"logo" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"metadata" text,
+	"slack_team_id" text NOT NULL,
+	CONSTRAINT "organization_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "organization_slackTeamId_unique" UNIQUE("slack_team_id")
+);
+--> statement-breakpoint
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_inviter_id_user_id_fk" FOREIGN KEY ("inviter_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member" ADD CONSTRAINT "member_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member" ADD CONSTRAINT "member_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/db/migrations/meta/0025_snapshot.json
+++ b/src/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,1220 @@
+{
+  "id": "bc4acc99-6a7a-4409-a341-ca459bf397ea",
+  "prevId": "0b93f748-fe31-4119-b2e1-ea7782819e3c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_team_id": {
+          "name": "slack_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_slackTeamId_unique": {
+          "name": "organization_slackTeamId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_team_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_message": {
+      "name": "auto_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_send_time": {
+          "name": "next_send_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_schedule": {
+          "name": "recurrence_schedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_new_topic": {
+          "name": "start_new_topic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deactivation_metadata": {
+          "name": "deactivation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auto_message_created_by_message_id_slack_message_id_fk": {
+          "name": "auto_message_created_by_message_id_slack_message_id_fk",
+          "tableFrom": "auto_message",
+          "tableTo": "slack_message",
+          "columnsFrom": [
+            "created_by_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meeting_artifact": {
+      "name": "meeting_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_event_id": {
+          "name": "calendar_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meeting_code": {
+          "name": "meeting_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meeting_uri": {
+          "name": "meeting_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conference_record": {
+          "name": "conference_record",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_uri": {
+          "name": "transcript_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_document_id": {
+          "name": "transcript_document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_fetched_at": {
+          "name": "transcript_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_last_checked_at": {
+          "name": "transcript_last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_attempt_count": {
+          "name": "transcript_attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gemini_summary": {
+          "name": "gemini_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model": {
+          "name": "gemini_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_posted_at": {
+          "name": "summary_posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_slack_channel_id": {
+          "name": "summary_slack_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_slack_ts": {
+          "name": "summary_slack_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_channel_id": {
+          "name": "origin_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_thread_ts": {
+          "name": "origin_thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meeting_artifact_topic_id_topic_id_fk": {
+          "name": "meeting_artifact_topic_id_topic_id_fk",
+          "tableFrom": "meeting_artifact",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meeting_artifact_calendar_event_unique": {
+          "name": "meeting_artifact_calendar_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_channel": {
+      "name": "slack_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_ids": {
+          "name": "user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_message": {
+      "name": "slack_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_ts": {
+          "name": "raw_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_ts": {
+          "name": "thread_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_message_id": {
+          "name": "auto_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "slack_message_topic_id_topic_id_fk": {
+          "name": "slack_message_topic_id_topic_id_fk",
+          "tableFrom": "slack_message",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_message_auto_message_id_auto_message_id_fk": {
+          "name": "slack_message_auto_message_id_auto_message_id_fk",
+          "tableFrom": "slack_message",
+          "tableTo": "auto_message",
+          "columnsFrom": [
+            "auto_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_user": {
+      "name": "slack_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "real_name": {
+          "name": "real_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic_state": {
+      "name": "topic_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_ids": {
+          "name": "user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "per_user_context": {
+          "name": "per_user_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_message_id": {
+          "name": "created_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "topic_state_topic_id_topic_id_fk": {
+          "name": "topic_state_topic_id_topic_id_fk",
+          "tableFrom": "topic_state",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "topic_state_created_by_message_id_slack_message_id_fk": {
+          "name": "topic_state_created_by_message_id_slack_message_id_fk",
+          "tableFrom": "topic_state",
+          "tableTo": "slack_message",
+          "columnsFrom": [
+            "created_by_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_data": {
+      "name": "user_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_data_slack_user_id_slack_user_id_fk": {
+          "name": "user_data_slack_user_id_slack_user_id_fk",
+          "tableFrom": "user_data",
+          "tableTo": "slack_user",
+          "columnsFrom": [
+            "slack_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_data_slack_user_id_unique": {
+          "name": "user_data_slack_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slack_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1758720076940,
       "tag": "0024_add_meeting_artifact_table",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1759254276545,
+      "tag": "0025_add_organization_member_and_invitation_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -1,3 +1,4 @@
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm'
 import {
   pgTable,
   text,
@@ -14,6 +15,8 @@ export const userTable = pgTable('user', {
   createdAt: timestamp().notNull().defaultNow(),
   updatedAt: timestamp().notNull().defaultNow().$onUpdate(() => new Date()),
 })
+export type UserInsert = InferInsertModel<typeof userTable>
+export type User = InferSelectModel<typeof userTable>
 
 export const sessionTable = pgTable('session', {
   id: text().primaryKey(),
@@ -25,6 +28,8 @@ export const sessionTable = pgTable('session', {
   userAgent: text(),
   userId: text().notNull().references(() => userTable.id, { onDelete: 'cascade' }),
 })
+export type SessionInsert = InferInsertModel<typeof sessionTable>
+export type Session = InferSelectModel<typeof sessionTable>
 
 export const accountTable = pgTable('account', {
   id: text().primaryKey(),
@@ -43,6 +48,8 @@ export const accountTable = pgTable('account', {
   installationId: text(),
   repositoryId: text(),
 })
+export type AccountInsert = InferInsertModel<typeof accountTable>
+export type Account = InferSelectModel<typeof accountTable>
 
 export const verificationTable = pgTable('verification', {
   id: text().primaryKey(),
@@ -52,10 +59,49 @@ export const verificationTable = pgTable('verification', {
   createdAt: timestamp().notNull().defaultNow(),
   updatedAt: timestamp().notNull().defaultNow().$onUpdate(() => new Date()),
 })
+export type VerificationInsert = InferInsertModel<typeof verificationTable>
+export type Verification = InferSelectModel<typeof verificationTable>
+
+export const organizationTable = pgTable('organization', {
+  id: text().primaryKey(),
+  name: text().notNull(),
+  slug: text().unique(),
+  logo: text(),
+  createdAt: timestamp().notNull().defaultNow(),
+  metadata: text(),
+  slackTeamId: text().notNull().unique(),
+})
+export type OrganizationInsert = InferInsertModel<typeof organizationTable>
+export type Organization = InferSelectModel<typeof organizationTable>
+
+export const memberTable = pgTable('member', {
+  id: text().primaryKey(),
+  organizationId: text().notNull().references(() => organizationTable.id, { onDelete: 'cascade' }),
+  userId: text().notNull().references(() => userTable.id, { onDelete: 'cascade' }),
+  role: text().default('member').notNull(),
+  createdAt: timestamp().notNull().defaultNow(),
+})
+export type MemberInsert = InferInsertModel<typeof memberTable>
+export type Member = InferSelectModel<typeof memberTable>
+
+export const invitationTable = pgTable('invitation', {
+  id: text().primaryKey(),
+  organizationId: text().notNull().references(() => organizationTable.id, { onDelete: 'cascade' }),
+  email: text().notNull(),
+  role: text(),
+  status: text().default('pending').notNull(),
+  expiresAt: timestamp().notNull(),
+  inviterId: text().notNull().references(() => userTable.id, { onDelete: 'cascade' }),
+})
+export type InvitationInsert = InferInsertModel<typeof invitationTable>
+export type Invitation = InferSelectModel<typeof invitationTable>
 
 export const betterAuthSchema = {
   user: userTable,
   session: sessionTable,
   account: accountTable,
   verification: verificationTable,
+  organization: organizationTable,
+  member: memberTable,
+  invitation: invitationTable,
 }

--- a/src/frontend/Home.tsx
+++ b/src/frontend/Home.tsx
@@ -1,27 +1,13 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Link } from 'react-router'
-import type { TopicWithState } from '@shared/api-types'
+import type { TopicWithState, UserProfile } from '@shared/api-types'
 import { unserializeTopicWithState } from '@shared/api-types'
 import { useAuth } from './auth-context'
 import { api, authClient } from '@shared/api-client'
 
-interface Profile {
-  user: {
-    id: string
-    email: string
-    name: string
-  }
-  slackAccount: {
-    id: string
-    realName: string | null
-    teamId: string
-    teamName?: string | null
-  } | null
-}
-
 function Home() {
   const [topics, setTopics] = useState<TopicWithState[]>([])
-  const [profile, setProfile] = useState<Profile | null>(null)
+  const [profile, setProfile] = useState<UserProfile | null>(null)
   const [userNameMap, setUserNameMap] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/src/frontend/Profile.tsx
+++ b/src/frontend/Profile.tsx
@@ -230,7 +230,7 @@ export default function Profile() {
         <h2 className="text-xl font-semibold text-gray-900 mb-4">Slack Account</h2>
         {profile.slackAccount ? (
           <div className="py-2 border-b border-gray-100">
-            <strong>{profile.slackAccount.realName || profile.slackAccount.id}</strong> (Team: {profile.slackAccount.teamName || profile.slackAccount.teamId})
+            Team: {profile.organization.name }
           </div>
         ) : (
           <p>No Slack account linked</p>
@@ -399,6 +399,15 @@ export default function Profile() {
           </>
         )}
       </div>
+
+      {profile.organization && (
+        <div className="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">Organization</h2>
+          <div className="bg-gray-50 border border-gray-300 rounded-lg px-4 py-3 inline-block">
+            <span className="font-medium text-gray-900">{profile.organization.name}</span>
+          </div>
+        </div>
+      )}
       </div>
     </div>
   )

--- a/src/frontend/Topic.tsx
+++ b/src/frontend/Topic.tsx
@@ -671,7 +671,7 @@ function Topic() {
                         context={userData?.context}
                         topicContext={topicUserContext}
                         userTimezone={user?.tz || null}
-                        onConnectClick={userId && topicId && profile?.slackAccount && profile.slackAccount.id === userId ? (() => {
+                        onConnectClick={userId && topicId && profile?.slackAccount && profile.slackAccount.accountId === userId ? (() => {
                           const currentPath = window.location.pathname + window.location.search
                           const params = new URLSearchParams({
                             callbackURL: currentPath,

--- a/src/integrations/slack.ts
+++ b/src/integrations/slack.ts
@@ -1,13 +1,9 @@
 import { and, eq } from 'drizzle-orm'
-import { WebClient } from '@slack/web-api'
 import db from '../db/engine'
 import { accountTable } from '../db/schema/auth'
-import { slackUserTable } from '../db/schema/main'
-import type { SlackAccount } from '@shared/api-types'
 
-export async function getLinkedSlackAccount(userId: string): Promise<SlackAccount | null> {
-  const linkedSlackIds = await db
-    .select({ slackId: accountTable.accountId })
+export async function getLinkedSlackAccount(userId: string) {
+  const [linkedSlackAccount] = await db.select()
     .from(accountTable)
     .where(and(
       eq(accountTable.userId, userId),
@@ -15,44 +11,11 @@ export async function getLinkedSlackAccount(userId: string): Promise<SlackAccoun
     ))
     .limit(1)
 
-  if (linkedSlackIds.length === 0) {
+  if (!linkedSlackAccount) {
     return null
   }
 
-  const slackId = linkedSlackIds[0].slackId
-
-  // Get Slack user details
-  const [slackUser] = await db
-    .select({
-      id: slackUserTable.id,
-      realName: slackUserTable.realName,
-      teamId: slackUserTable.teamId,
-    })
-    .from(slackUserTable)
-    .where(eq(slackUserTable.id, slackId))
-    .limit(1)
-
-  const teamId = slackUser?.teamId ?? 'unknown'
-
-  // Best-effort team name using bot token (only resolves current workspace)
-  let teamName: string | null = null
-  try {
-    if (process.env.PV_SLACK_BOT_TOKEN && teamId !== 'unknown') {
-      const client = new WebClient(process.env.PV_SLACK_BOT_TOKEN)
-      const info = await client.team.info()
-      if (info.ok && info.team?.id === teamId && info.team?.name) {
-        teamName = info.team.name
-      }
-    }
-  } catch (err) {
-    console.warn('team.info failed:', err)
-  }
-
-  // Return the slack account info, mirroring the structure from api.ts
   return {
-    id: slackId,
-    realName: slackUser?.realName ?? null,
-    teamId,
-    teamName,
+    accountId: linkedSlackAccount.accountId,
   }
 }

--- a/src/shared/api-client.ts
+++ b/src/shared/api-client.ts
@@ -1,6 +1,7 @@
 import { hc } from 'hono/client'
 import { createAuthClient } from 'better-auth/client'
 import type { BetterAuthClientPlugin } from 'better-auth/client'
+import { organizationClient } from 'better-auth/client/plugins'
 import type { AppType } from '../server'
 import type { githubAppInstallationPlugin } from '../auth'
 
@@ -27,6 +28,7 @@ function githubAppInstallationPluginClient() {
 
 export const authClient = createAuthClient({
   plugins: [
+    organizationClient(),
     githubAppInstallationPluginClient(),
   ],
 })

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -57,11 +57,10 @@ export interface GithubAccount {
   linkableRepos: BotRepository[]
 }
 
-export interface SlackAccount {
+export interface ProfileOrg {
   id: string
-  realName: string | null
-  teamId: string
-  teamName?: string | null
+  name: string
+  slackTeamId: string
 }
 
 export interface UserProfile {
@@ -70,9 +69,10 @@ export interface UserProfile {
     email: string
     name: string
   }
-  slackAccount: SlackAccount | null
+  slackAccount: { accountId: string } | null
   googleAccount: { accountId: string } | null
   githubAccount: GithubAccount | null
+  organization: ProfileOrg
 }
 
 export interface AutoMessageDeactivation {


### PR DESCRIPTION
Summary:
When users log in via slack (currently the only login method), it now assigns them to a better-auth organization based on the slack team id they've authorized for their account. The organization is created if it does not exist, and users cannot create organizations any other way.

Includes the addition of the better-auth organization plugin, and corresponding migrations for the required tables.

Test Plan:
Logged in and out locally, and saw organization and membership created in the DB