### PR TITLE
Fixes issue #75, Pivotal ends conversations early.

### DIFF
--- a/src/agents/conversation-utils.ts
+++ b/src/agents/conversation-utils.ts
@@ -77,7 +77,7 @@ Based on the conversation history and current message, determine the next step i
   console.log(`User prompt: ${userPrompt}`)
 
   const MAX_ATTEMPTS = 2
-  const retryReminder = `\n\nIMPORTANT: Your previous response was not valid JSON. You must now return ONLY a JSON object that exactly matches the required schema, including the reasoning field. Do not include any extra text before or after the JSON.`
+  const retryReminder = '\n\nIMPORTANT: Your previous response was not valid JSON. You must now return ONLY a JSON object that exactly matches the required schema, including the reasoning field. Do not include any extra text before or after the JSON.'
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const promptToUse = attempt === 0 ? userPrompt : `${userPrompt}${retryReminder}`

--- a/src/agents/scheduling.ts
+++ b/src/agents/scheduling.ts
@@ -271,7 +271,7 @@ Based on the current state, determine what tools to call (if any) and generate t
     * Example: "I'm busy 2-3pm" → ONLY create: 2pm-3pm (busy). Do NOT add any free events.
 
 ## CRITICAL TOOL USAGE
-You have access to FOUR tools, but you can ONLY USE ONE per response:
+You have access to FOUR tools and can call multiple tools in sequence within the same turn. After a tool completes, you'll immediately get another chance to act—keep calling whichever tools you still need until you're ready to send the final JSON response. Only return JSON once all necessary tool calls for this turn are finished; never stop mid-sequence with an empty reply.
 
 1. **findFreeSlots**: Finds mathematically accurate free time slots
    - USE THIS before proposing any meeting times when you have calendar data
@@ -332,6 +332,7 @@ When NOT calling a tool, return ONLY a JSON object with these fields:
 }
 
 IMPORTANT:
+- Any time you are not calling a tool, you MUST return well-formed JSON that exactly matches the schema above. Do not return plain text or partial structures. Always include the reasoning field, even if replyMessage is an empty string.
 - When calling tools: Output NOTHING - just call the tool
 - When not calling tools: Return ONLY the JSON object above
 - Do not include any text before or after the JSON`


### PR DESCRIPTION
Summary:
Pivotal had a particular failure mode of ending conversations early (especially while planning with multiple people). This happened because the agent would fail to output a correctly formatted JSON. This is fixed 1) by two amendments to the system prompt, and 2) adding an automatic retry with a message ("Your previous response was not valid JSON. You must ...").

Test Plan:
Tested this with the great new evals framework. The system prompt got about 1/2 of the low hanging fruit errors, the automatic retry caught everything else.

In particular, tested via pnpm run eval --benchmarkFolder=benchmark_4simusers_2groups_1-33start_1-75end_60min
  --nReps=3".