### PR TITLE
Fix scheduling agent tool-use errors, and fix #70.

### DIFF
--- a/src/agents/conversation-utils.ts
+++ b/src/agents/conversation-utils.ts
@@ -43,6 +43,126 @@ export const ConversationAgent = Agent<ConversationContext, typeof ConversationR
 export type ConversationRes = z.infer<typeof ConversationRes>
 export type ConversationAgent = InstanceType<typeof ConversationAgent>
 
+type AgentsErrorWithState = Error & { state?: Record<string, unknown> }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function extractAssistantOutputFromState(state: unknown): string | undefined {
+  if (!isRecord(state)) return undefined
+  const response = state._lastTurnResponse
+  if (!isRecord(response)) return undefined
+  const output = response.output
+  if (!Array.isArray(output)) return undefined
+
+  const outputItems: unknown[] = output
+
+  for (let i = outputItems.length - 1; i >= 0; i -= 1) {
+    const item = outputItems[i]
+    if (!isRecord(item)) continue
+    const messageCandidate = item as {
+      type?: unknown,
+      role?: unknown,
+      content?: unknown,
+    }
+    if (messageCandidate.type !== 'message') continue
+    if (messageCandidate.role !== 'assistant') continue
+    const content = messageCandidate.content
+    if (!Array.isArray(content) || content.length === 0) continue
+    const contentItems: unknown[] = content
+    const lastChunk = contentItems[contentItems.length - 1]
+    if (!isRecord(lastChunk)) continue
+    const chunkCandidate = lastChunk as {
+      type?: unknown,
+      text?: unknown,
+    }
+    if (chunkCandidate.type !== 'output_text') continue
+    if (typeof chunkCandidate.text === 'string') {
+      return chunkCandidate.text
+    }
+  }
+
+  return undefined
+}
+
+function sanitizeFencedJson(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed.startsWith('```')) return trimmed
+  const withoutFence = trimmed.replace(/^```[a-zA-Z]*\s*/, '')
+  const closingIndex = withoutFence.lastIndexOf('```')
+  if (closingIndex === -1) return withoutFence
+  return withoutFence.slice(0, closingIndex).trim()
+}
+
+type InvalidOutputAnalysis = {
+  preview?: string,
+  issues: string[],
+}
+
+const INVALID_PREVIEW_LIMIT = 600
+
+function analyseInvalidStructuredOutput(rawText?: string): InvalidOutputAnalysis {
+  if (!rawText) {
+    return {
+      preview: undefined,
+      issues: ['No assistant JSON output was returned.'],
+    }
+  }
+
+  const preview = rawText.length > INVALID_PREVIEW_LIMIT
+    ? `${rawText.slice(0, INVALID_PREVIEW_LIMIT)}…`
+    : rawText
+
+  const issues: string[] = []
+
+  const sanitised = sanitizeFencedJson(rawText)
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(sanitised)
+  } catch (error) {
+    issues.push(`Response was not valid JSON (${error instanceof Error ? error.message : 'unknown parse error'})`)
+    return { preview, issues }
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    issues.push('Response must be a JSON object matching the schema.')
+    return { preview, issues }
+  }
+
+  const reasoning = (parsed as { reasoning?: unknown }).reasoning
+  if (typeof reasoning !== 'string') {
+    issues.push('`reasoning` is required and must be a string (use a short explanation).')
+  }
+
+  if ('replyMessage' in parsed) {
+    const replyMessage = (parsed as { replyMessage: unknown }).replyMessage
+    const validReply = typeof replyMessage === 'string' || replyMessage === null
+    if (!validReply) {
+      issues.push('`replyMessage` must be a string (use "" when waiting) or null.')
+    }
+  }
+
+  return { preview, issues }
+}
+
+function formatRetryGuidance(preview?: string, issues: string[] = []): string {
+  if (!preview && issues.length === 0) return ''
+  const hints: string[] = []
+  if (preview) {
+    hints.push(`Your previous response was:
+${preview}`)
+  }
+  if (issues.length > 0) {
+    hints.push(`Fix the following problems before responding again: ${issues.join(' ')}`)
+  }
+  return `
+
+Additional guidance based on your last response:
+${hints.join('\n\n')}`
+}
+
 export async function runConversationAgent(
   agent: ConversationAgent,
   message: SlackMessage,
@@ -77,10 +197,16 @@ Based on the conversation history and current message, determine the next step i
   console.log(`User prompt: ${userPrompt}`)
 
   const MAX_ATTEMPTS = 2
-  const retryReminder = '\n\nIMPORTANT: Your previous response was not valid JSON. You must now return ONLY a JSON object that exactly matches the required schema, including the reasoning field. Do not include any extra text before or after the JSON.'
+  const retryReminder = '\n\nIMPORTANT: Your previous response was not valid structured output.\n- If you still need information from a tool, call the tool now and output nothing else.\n- Otherwise, return ONLY the JSON object that matches the required schema (replyMessage, markTopicInactive, messagesToUsers, groupMessage, finalizedEvent, cancelEvent, reasoning).\n- replyMessage must be a string (use "" when you have nothing to add) and reasoning is ALWAYS required.\n- Never mix tool calls with JSON in the same response, and do not include any extra text before or after the JSON.'
+
+  let lastInvalidPreview: string | undefined
+  let lastInvalidIssues: string[] = []
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    const promptToUse = attempt === 0 ? userPrompt : `${userPrompt}${retryReminder}`
+    const retryDetails = attempt === 0 ? '' : formatRetryGuidance(lastInvalidPreview, lastInvalidIssues)
+    const promptToUse = attempt === 0
+      ? userPrompt
+      : `${userPrompt}${retryReminder}${retryDetails}`
 
     try {
       const runner = new Runner({ groupId: `topic-${topic.id}` })
@@ -95,16 +221,37 @@ Based on the conversation history and current message, determine the next step i
       return result.finalOutput
     } catch (error) {
       const isInvalidOutput = error instanceof Error && error.message.includes('Invalid output type')
+      const errorSummary = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+      const stackPreview = error instanceof Error && typeof error.stack === 'string'
+        ? error.stack.split('\n').slice(0, 5).join('\n')
+        : 'No stack trace'
 
-      if (isInvalidOutput && attempt === 0) {
-        console.warn('Retrying conversation agent due to invalid output type (missing/invalid JSON).')
-        continue
+      if (isInvalidOutput) {
+        const state = (error as AgentsErrorWithState).state
+        const rawOutput = extractAssistantOutputFromState(state)
+        const analysis = analyseInvalidStructuredOutput(rawOutput)
+        lastInvalidPreview = analysis.preview
+        lastInvalidIssues = analysis.issues
+
+        if (analysis.preview) {
+          console.warn('[ConversationAgent] Invalid output preview (truncated):', analysis.preview)
+        }
+        if (analysis.issues.length > 0) {
+          console.warn('[ConversationAgent] Detected structured output issues:', analysis.issues.join(' '))
+        }
+
+        console.warn(`[ConversationAgent] Invalid structured output (attempt ${attempt + 1}/${MAX_ATTEMPTS}). Summary: ${errorSummary}`)
+        console.warn('[ConversationAgent] Stack preview:', stackPreview)
+        if (attempt === 0) {
+          console.warn('[ConversationAgent] Retrying with explicit JSON instructions.')
+          continue
+        }
       }
 
       console.error('=== ERROR IN runConversationAgent ===')
       console.error('Error type:', error instanceof Error ? error.constructor.name : typeof error)
       console.error('Error message:', error instanceof Error ? error.message : String(error))
-      console.error('Stack trace:', error instanceof Error ? error.stack : 'No stack trace')
+      console.error('Stack trace:', stackPreview)
       console.error('Full error object:', JSON.stringify(error, null, 2))
       console.error('=================================')
 

--- a/src/agents/langfuse-tracing-exporter.ts
+++ b/src/agents/langfuse-tracing-exporter.ts
@@ -195,6 +195,18 @@ export class LangfuseTracingExporter implements TracingExporter {
       statusMessage: span.error?.message,
     }
 
+    if (span.error?.message?.includes('Invalid output type')) {
+      try {
+        const serialized = typeof data.output === 'string'
+          ? data.output
+          : JSON.stringify(data.output)
+        const preview = serialized.length > 1500 ? `${serialized.slice(0, 1500)}…` : serialized
+        console.warn('[ConversationAgent] Model returned invalid structured output. Preview:', preview)
+      } catch (serializationError) {
+        console.warn('[ConversationAgent] Model returned invalid structured output, but output could not be serialized for logging.', serializationError)
+      }
+    }
+
     if (span.parentId) {
       // If there's a parentId, this is a child of a span, so queue to be exported later
       const parentChildren = this.spanIdToChildrenParams.get(span.parentId) || []

--- a/src/agents/scheduling.ts
+++ b/src/agents/scheduling.ts
@@ -335,7 +335,21 @@ IMPORTANT:
 - Any time you are not calling a tool, you MUST return well-formed JSON that exactly matches the schema above. Do not return plain text or partial structures. Always include the reasoning field, even if replyMessage is an empty string.
 - When calling tools: Output NOTHING - just call the tool
 - When not calling tools: Return ONLY the JSON object above
-- Do not include any text before or after the JSON`
+- Do not include any text before or after the JSON
+- Common mistakes to avoid:
+  * Forgetting to include the "reasoning" field
+  * Mixing tool calls and JSON in the same response
+  * Returning acknowledgements or prose instead of JSON
+- Example waiting response:
+  {
+    "replyMessage": "",
+    "markTopicInactive": false,
+    "messagesToUsers": null,
+    "groupMessage": null,
+    "finalizedEvent": null,
+    "cancelEvent": null,
+    "reasoning": "Waiting for Bob to confirm availability"
+  }`
 
   const { topic, userMap, callingUserTimezone } = runContext.context
 


### PR DESCRIPTION
Summary:
Scheduling topics would surface "Invalid output type" errors for a variety of reasons. I found the generic error could be decomposed into three subtypes of errors: replying with plain text, a fenced JSON, or missing reasoning. To fix this, we 1) add some introspection in conversation-utils to pinpoint which schema rule was broken, 2) and feed this into a tailored retry message for the model. Now, the second attempt can fix the actual issue instead of causing the LLM to generically bail. Also, the logs help explain what went wrong (helping us debug in the future).

Limitations:
I am fixing 'schema' errors here, not 'behavioral' errors. We didn’t touch the scheduling logic itself, so scheduling failures like time-window issues are not being fixed here. This commit is rather trying to fix the broad class of reasons for why the LLM may not be output format compliant.

Testing:
  - pnpm run lint
  - Evals fw. In particular, pnpm run eval --benchmarkFolder=benchmark_4simusers_2groups_1-33start_1- 75end_60min --nReps=3.