### PR TITLE
Introduces queryAgent

### DIFF
--- a/src/agents/analyze-topic-relevance.ts
+++ b/src/agents/analyze-topic-relevance.ts
@@ -63,7 +63,8 @@ Given a list of existing topics and a new message, determine:
 When suggesting a new topic, also classify its workflow type:
 - "scheduling": The topic involves planning, organizing, or scheduling meetings, events, or activities (e.g., "plan lunch", "schedule meeting", "organize team event")
 - "meeting-prep": The topic involves preparing for an upcoming meeting by gathering updates, creating agendas, or collecting input from participants (e.g., "prepare agenda for tomorrow's standup", "gather updates for the quarterly review", "compile discussion topics for the team meeting")
-- "other": All other topics that don't involve scheduling or meeting preparation
+- "queries": The topic is focused on answering questions, retrieving information, or checking statuses (e.g., "is my calendar connected?", "what was the summary from Monday's meeting?", "did Parker reply?")
+- "other": All other topics that don't fit the above categories
 
 ## Response Format
 You must respond with ONLY a JSON object - no additional text, markdown formatting, or explanations. Return ONLY valid JSON that can be parsed directly.
@@ -72,7 +73,7 @@ The JSON structure must be:
 {
   "relevantTopicId": "e55a48d1-bf81-4f7f-8848-d0f69b74ff85",  // Include the full UUID from "Topic ID: ..." if message is relevant to existing topic
   "suggestedNewTopic": "New topic summary",                   // Include only if relevantTopicId is not populated
-  "workflowType": "scheduling",                               // Include only when suggestedNewTopic is present. Must be "scheduling", "meeting-prep", or "other"
+  "workflowType": "scheduling",                               // Include only when suggestedNewTopic is present. Must be "scheduling", "meeting-prep", "queries", or "other"
   "confidence": 0.85,                                         // Confidence level between 0 and 1
   "reasoning": "Brief explanation"                            // One sentence explaining the decision
 }

--- a/src/agents/conversation-utils.ts
+++ b/src/agents/conversation-utils.ts
@@ -37,6 +37,11 @@ export const ConversationRes = z.strictObject({
   groupMessage: z.string().optional().nullable(),
   finalizedEvent: CalendarEvent.optional().nullable(),
   cancelEvent: z.boolean().optional().nullable(),
+  promptCalendarButtons: z.strictObject({
+    userName: z.string().optional().nullable(),
+    contextMessage: z.string().optional().nullable(),
+    force: z.boolean().optional().nullable(),
+  }).optional().nullable(),
   reasoning: z.string(),
 })
 export const ConversationAgent = Agent<ConversationContext, typeof ConversationRes>

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,10 +2,12 @@ import type { WorkflowType } from '@shared/api-types'
 import type { ConversationAgent } from './conversation-utils'
 import { schedulingAgent } from './scheduling'
 import { meetingPrepAgent } from './meeting-prep'
+import { queryAgent } from './queries'
 
 export const workflowAgentMap = new Map<WorkflowType, ConversationAgent>([
   ['scheduling', schedulingAgent],
   ['meeting-prep', meetingPrepAgent],
+  ['queries', queryAgent],
 ])
 
 export { analyzeTopicRelevance } from './analyze-topic-relevance'

--- a/src/agents/meeting-prep.ts
+++ b/src/agents/meeting-prep.ts
@@ -7,13 +7,16 @@ import { formatTimestampWithTimezone } from '../utils'
 import { getShortTimezoneFromIANA } from '@shared/utils'
 
 async function meetingPrepInstructions(runContext: RunContext<ConversationContext>) {
-  const mainPrompt = `You are a meeting preparation assistant that helps create meeting agendas. Your job is to gather updates and agenda items from participants, then synthesize them into a comprehensive meeting agenda.
+const mainPrompt = `You are a meeting preparation assistant that helps create meeting agendas. Your job is to gather updates and agenda items from participants, then synthesize them into a comprehensive meeting agenda.
 
 ## Current Context
 You will receive:
 - The current message from a user
 - The topic information including all users currently involved
 - The topic summary describing what has been prepared so far
+
+## Responsiveness
+- Always send a concise, helpful reply whenever the user pings you directly or mentions you. Do not leave questions unanswered.
 
 ## Your Task
 Based on the current state, determine what tools to call (if any) and generate the appropriate message(s) to users to gather updates and create the meeting agenda

--- a/src/agents/queries.ts
+++ b/src/agents/queries.ts
@@ -1,0 +1,578 @@
+import { z } from 'zod'
+
+import { tool } from './agent-sdk'
+import type { RunContext } from './agent-sdk'
+import type { ConversationContext } from './conversation-utils'
+import { ConversationAgent, ConversationRes } from './conversation-utils'
+import { isGoogleCalendarConnected } from '../integrations/google'
+import { findMeetingsForUsers } from '../meeting-artifacts'
+import { getUserCalendarStructured } from '../calendar-service'
+import { formatTimestampWithTimezone } from '../utils'
+import { Temporal } from '@js-temporal/polyfill'
+import db from '../db/engine'
+import { slackMessageTable, slackChannelTable } from '../db/schema/main'
+import { eq } from 'drizzle-orm'
+import { findCommonFreeTime, convertCalendarEventsToUserProfile } from '../tools/time_intersection'
+import type { UserProfile as CalendarIntersectionProfile } from '../tools/time_intersection'
+
+function formatDurationMinutes(minutesTotal: number): string {
+  if (minutesTotal <= 1) return '1 minute'
+  if (minutesTotal < 60) return `${minutesTotal} minutes`
+  const hours = Math.floor(minutesTotal / 60)
+  const minutes = minutesTotal % 60
+  if (minutes === 0) return `${hours} hour${hours === 1 ? '' : 's'}`
+  return `${hours}h ${minutes}m`
+}
+
+function describeElapsedSince(date: Date, now: Date): string {
+  const diffMs = now.getTime() - date.getTime()
+  if (diffMs < 0) return 'in the future'
+  const diffMinutes = Math.floor(diffMs / (60_000))
+  if (diffMinutes < 1) return 'just now'
+  if (diffMinutes < 60) return `${diffMinutes} minutes ago`
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) {
+    const remainMinutes = diffMinutes % 60
+    if (remainMinutes === 0) return `${diffHours} hours ago`
+    return `${diffHours}h ${remainMinutes}m ago`
+  }
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 7) return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
+  const diffWeeks = Math.floor(diffDays / 7)
+  return `${diffWeeks} week${diffWeeks === 1 ? '' : 's'} ago`
+}
+
+function findLast<T>(items: readonly T[], predicate: (item: T) => boolean): T | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const candidate = items[index]
+    if (predicate(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+type AvailabilityParticipantSummary = {
+  name: string
+  status: 'ok' | 'no_calendar_data' | 'error'
+  detail?: string
+  busyBlockCount?: number
+}
+
+type AvailabilityFreeBlock = {
+  start: string
+  startLocal: string
+  end: string
+  endLocal: string
+  durationMinutes: number
+  durationReadable: string
+}
+
+type AvailabilityPayload = {
+  window: {
+    start: string
+    end: string
+    timezone: string
+  }
+  participants: AvailabilityParticipantSummary[]
+  unresolvedNames: string[]
+  freeBlocks: AvailabilityFreeBlock[]
+  note?: string
+}
+
+const checkCalendarConnection = tool({
+  name: 'checkCalendarConnection',
+  description: 'Check whether specified Slack users have their Google Calendar connected. Pass exact real names from the User Directory. Leave the list empty to check only the requesting user.',
+  parameters: z.strictObject({
+    userNames: z.array(z.string()).describe('Exact real names of the users to check. Use the User Directory names. Leave empty to check the requester.'),
+  }),
+  execute: async ({ userNames }, runContext?: RunContext<ConversationContext>) => {
+    if (!runContext) throw new Error('runContext not provided')
+    const { message, userMap } = runContext.context
+
+    const results: string[] = []
+    const pendingIds: Array<{ userId: string, name: string }> = []
+
+    if (userNames.length === 0) {
+      const selfName = userMap.get(message.userId)?.realName ?? 'You'
+      pendingIds.push({ userId: message.userId, name: selfName })
+    } else {
+      for (const requestedName of userNames) {
+        let matchedId: string | undefined
+        let matchedRealName: string | undefined
+        for (const [candidateId, candidate] of userMap.entries()) {
+          const realName = candidate.realName || ''
+          if (realName && realName.localeCompare(requestedName, undefined, { sensitivity: 'base' }) === 0) {
+            matchedId = candidateId
+            matchedRealName = realName
+            break
+          }
+        }
+
+        if (!matchedId) {
+          results.push(`${requestedName}: user not found in directory.`)
+          continue
+        }
+
+        pendingIds.push({ userId: matchedId, name: matchedRealName ?? requestedName })
+      }
+    }
+
+    const lines: string[] = []
+
+    for (const target of pendingIds) {
+      try {
+        const connected = await isGoogleCalendarConnected(target.userId)
+        lines.push(`${target.name}: ${connected ? '✅ Connected' : '❌ Not connected'}`)
+      } catch (error) {
+        lines.push(`${target.name}: Unable to check (${error instanceof Error ? error.message : 'unknown error'})`)
+      }
+    }
+
+    return lines.join('\n')
+  },
+})
+
+const lookupMeetings = tool({
+  name: 'lookupMeetings',
+  description: 'Retrieve meetings recorded by Pivotal for specified users. Useful for questions like "What\'s my next meeting?" or "Send me the meeting link again."',
+  parameters: z.strictObject({
+    userNames: z.array(z.string()).optional().default([]).describe('Exact real names (from the User Directory) to find meetings for. Leave empty to reference the requesting user.'),
+    summaryContains: z.string().optional().nullable().describe('Optional text to match within the meeting summary (case-insensitive).'),
+    direction: z.enum(['upcoming', 'past']).optional().default('upcoming').describe('Whether to look for upcoming or past meetings.'),
+    limit: z.number().int().positive().max(10).optional().default(3).describe('Maximum number of meetings to return.'),
+  }),
+  execute: async ({ userNames, summaryContains, direction, limit }, runContext?: RunContext<ConversationContext>) => {
+    if (!runContext) throw new Error('runContext not provided')
+    const { message, userMap, callingUserTimezone } = runContext.context
+
+    const targetIds: { id: string, name: string }[] = []
+    const missingNames: string[] = []
+    if (userNames.length === 0) {
+      targetIds.push({ id: message.userId, name: userMap.get(message.userId)?.realName || 'You' })
+    } else {
+      for (const requestedName of userNames) {
+        const match = Array.from(userMap.entries()).find(([, user]) => {
+          const realName = user.realName || ''
+          return realName.localeCompare(requestedName, undefined, { sensitivity: 'base' }) === 0
+        })
+
+        if (!match) {
+          missingNames.push(requestedName)
+          continue
+        }
+        targetIds.push({ id: match[0], name: match[1].realName || requestedName })
+      }
+    }
+
+    if (targetIds.length === 0) {
+      if (missingNames.length > 0) {
+        return `Could not find these users in the directory: ${missingNames.join(', ')}`
+      }
+      return 'No users specified to search for meetings.'
+    }
+
+    const meetings = await findMeetingsForUsers({
+      userIds: targetIds.map((entry) => entry.id),
+      direction,
+      summaryContains: summaryContains ?? undefined,
+      limit,
+    })
+
+    if (meetings.length === 0) {
+      return 'No meetings found that match those criteria.'
+    }
+
+    const lines: string[] = []
+    meetings.forEach(({ artifact, topic }, index) => {
+      const summary = artifact.summary || topic.state.summary || 'Meeting'
+      const start = formatTimestampWithTimezone(artifact.startTime, callingUserTimezone)
+      const end = formatTimestampWithTimezone(artifact.endTime, callingUserTimezone)
+      const participantNames = topic.state.userIds
+        .map((id) => userMap.get(id)?.realName || id)
+        .join(', ')
+      const linkLine = artifact.meetingUri ? `\n  Link: ${artifact.meetingUri}` : ''
+      const topicLine = `\n  Topic ID: ${topic.id}`
+
+      lines.push(`${index + 1}. ${summary}\n  When: ${start} – ${end}\n  Participants: ${participantNames}${linkLine}${topicLine}`)
+    })
+
+    return lines.join('\n\n')
+  },
+})
+
+const getCalendarEvents = tool({
+  name: 'getCalendarEvents',
+  description: 'Fetch upcoming or recent calendar events (including busy blocks) directly from connected calendars. Provide a time range to inspect.',
+  parameters: z.strictObject({
+    userNames: z.array(z.string()).optional().default([]).describe('Exact real names (from the User Directory). Leave empty to use the requester.'),
+    rangeHours: z.number().int().positive().max(24 * 30).optional().default(24 * 7).describe('How many hours ahead to look (default 7 days).'),
+    includePastHours: z.number().int().min(0).max(24 * 7).optional().default(0).describe('How many hours back to include (default 0).'),
+  }),
+  execute: async ({ userNames, rangeHours, includePastHours }, runContext?: RunContext<ConversationContext>) => {
+    if (!runContext) throw new Error('runContext not provided')
+    const { message, topic, userMap, callingUserTimezone } = runContext.context
+
+    const targets: { id: string, name: string }[] = []
+    const notFound: string[] = []
+
+    if (userNames.length === 0) {
+      targets.push({ id: message.userId, name: userMap.get(message.userId)?.realName || 'You' })
+    } else {
+      for (const requestedName of userNames) {
+        const match = Array.from(userMap.entries()).find(([, user]) => {
+          const realName = user.realName || ''
+          return realName.localeCompare(requestedName, undefined, { sensitivity: 'base' }) === 0
+        })
+        if (!match) {
+          notFound.push(requestedName)
+          continue
+        }
+        targets.push({ id: match[0], name: match[1].realName || requestedName })
+      }
+    }
+
+    if (targets.length === 0) {
+      return notFound.length > 0
+        ? `Could not find these users in the directory: ${notFound.join(', ')}`
+        : 'No users specified to search for events.'
+    }
+
+    const now = Temporal.Now.instant()
+    const start = includePastHours > 0
+      ? now.subtract({ hours: includePastHours })
+      : now
+    const end = now.add({ hours: rangeHours })
+
+    const lines: string[] = []
+
+    for (const target of targets) {
+      try {
+        const events = await getUserCalendarStructured(
+          target.id,
+          topic,
+          new Date(start.epochMilliseconds),
+          new Date(end.epochMilliseconds),
+        )
+
+        if (!events || events.length === 0) {
+          lines.push(`${target.name}: No events found in the requested window.`)
+          continue
+        }
+
+        const formatted = events
+          .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
+          .map((event, idx) => {
+            const startStr = formatTimestampWithTimezone(new Date(event.start), callingUserTimezone)
+            const endStr = formatTimestampWithTimezone(new Date(event.end), callingUserTimezone)
+            const title = event.summary || (event.free ? 'Available' : 'Busy')
+            const participants = event.participantEmails?.length ? `\n      Participants: ${event.participantEmails.join(', ')}` : ''
+            return `    ${idx + 1}. ${title}\n      When: ${startStr} – ${endStr}${participants}`
+          })
+
+        lines.push(`${target.name}:\n${formatted.join('\n')}`)
+      } catch (error) {
+        lines.push(`${target.name}: Unable to fetch events (${error instanceof Error ? error.message : 'unknown error'})`)
+      }
+    }
+
+    if (notFound.length > 0) {
+      lines.push(`Could not find: ${notFound.join(', ')}`)
+    }
+
+    return lines.join('\n\n')
+  },
+})
+
+const findCommonAvailability = tool({
+  name: 'findCommonAvailability',
+  description: 'Find overlapping free time for multiple users within a specific window. Useful for questions like "When are Parker and I both free tomorrow?"',
+  parameters: z.strictObject({
+    userNames: z.array(z.string()).min(1).describe('Exact real names (from the User Directory) to include in the overlap calculation. The requester must be included explicitly if you want them considered.'),
+    startTime: z.string().describe('ISO 8601 timestamp for the start of the window (e.g., "2025-10-02T13:00:00-04:00").'),
+    endTime: z.string().describe('ISO 8601 timestamp for the end of the window. Must be later than startTime.'),
+    minBlockMinutes: z.number().int().min(5).max(24 * 60).optional().default(30).describe('Only return free blocks that are at least this many minutes long (default 30 minutes).'),
+    maxResults: z.number().int().min(1).max(10).optional().default(5).describe('Maximum number of free blocks to return (default 5).'),
+  }),
+  execute: async ({ userNames, startTime, endTime, minBlockMinutes, maxResults }, runContext?: RunContext<ConversationContext>) => {
+    if (!runContext) throw new Error('runContext not provided')
+    const { topic, userMap, callingUserTimezone } = runContext.context
+
+    const start = new Date(startTime)
+    const end = new Date(endTime)
+
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return 'Invalid startTime or endTime. Provide ISO timestamps such as 2025-10-02T13:00:00-04:00.'
+    }
+    if (end <= start) {
+      return 'endTime must be after startTime.'
+    }
+
+    const nameToId = new Map<string, string>()
+    userMap.forEach((user, id) => {
+      if (user.realName) {
+        nameToId.set(user.realName, id)
+      }
+    })
+
+    const targets: Array<{ id: string, name: string }> = []
+    const unresolvedNames: string[] = []
+    userNames.forEach((requestedName) => {
+      const matchEntry = Array.from(userMap.entries()).find(([, user]) => {
+        const realName = user.realName || ''
+        return realName.localeCompare(requestedName, undefined, { sensitivity: 'base' }) === 0
+      })
+      if (!matchEntry) {
+        unresolvedNames.push(requestedName)
+        return
+      }
+      targets.push({ id: matchEntry[0], name: matchEntry[1].realName || requestedName })
+    })
+
+    if (targets.length === 0) {
+      return unresolvedNames.length > 0
+        ? `No calendars available. Could not resolve: ${unresolvedNames.join(', ')}`
+        : 'No users provided to compare availability.'
+    }
+
+    const timelines = await Promise.all(targets.map(async (target) => {
+      try {
+        const events = await getUserCalendarStructured(target.id, topic, start, end)
+        if (events === null) {
+          return { target, events: null }
+        }
+        return { target, events }
+      } catch (error) {
+        return {
+          target,
+          error: error instanceof Error ? error.message : 'unknown error',
+        }
+      }
+    }))
+
+    const profiles: CalendarIntersectionProfile[] = []
+    const participantSummaries: AvailabilityParticipantSummary[] = []
+    timelines.forEach((entry) => {
+      if ('error' in entry) {
+        participantSummaries.push({
+          name: entry.target.name,
+          status: 'error',
+          detail: entry.error,
+        })
+        return
+      }
+      if (entry.events === null) {
+        participantSummaries.push({
+          name: entry.target.name,
+          status: 'no_calendar_data',
+        })
+        return
+      }
+      const converted = convertCalendarEventsToUserProfile(entry.events)
+      profiles.push({ name: entry.target.name, calendar: converted })
+      participantSummaries.push({
+        name: entry.target.name,
+        status: 'ok',
+        busyBlockCount: converted.length,
+      })
+    })
+
+    if (profiles.length === 0) {
+      const notes = timelines.map((entry) => {
+        if ('error' in entry) {
+          return `${entry.target.name}: error fetching calendar (${entry.error})`
+        }
+        return `${entry.target.name}: no calendar data available`
+      })
+      const prefix = unresolvedNames.length > 0 ? `Could not resolve: ${unresolvedNames.join(', ')}. ` : ''
+      return `${prefix}No overlapping availability can be calculated because no calendars were accessible.\n${notes.join('\n')}`
+    }
+
+    const commonFree = findCommonFreeTime(profiles, start, end)
+      .map((slot) => {
+        const durationMinutes = Math.floor((slot.end.getTime() - slot.start.getTime()) / 60000)
+        return {
+          start: slot.start,
+          end: slot.end,
+          durationMinutes,
+        }
+      })
+      .filter((slot) => slot.durationMinutes >= minBlockMinutes)
+      .sort((a, b) => a.start.getTime() - b.start.getTime())
+      .slice(0, maxResults)
+
+    const payload: AvailabilityPayload = {
+      window: {
+        start: start.toISOString(),
+        end: end.toISOString(),
+        timezone: callingUserTimezone,
+      },
+      participants: participantSummaries,
+      unresolvedNames,
+      freeBlocks: commonFree.map((slot) => ({
+        start: slot.start.toISOString(),
+        startLocal: formatTimestampWithTimezone(slot.start, callingUserTimezone),
+        end: slot.end.toISOString(),
+        endLocal: formatTimestampWithTimezone(slot.end, callingUserTimezone),
+        durationMinutes: slot.durationMinutes,
+        durationReadable: formatDurationMinutes(slot.durationMinutes),
+      })),
+    }
+
+    if (payload.freeBlocks.length === 0) {
+      payload.note = 'No overlapping free time found in the requested window.'
+    }
+
+    return JSON.stringify(payload, null, 2)
+  },
+})
+
+const getParticipantResponseStatus = tool({
+  name: 'getParticipantResponseStatus',
+  description: 'Summarize who has responded in the current scheduling topic. Helpful for questions like "Did Ben respond?" or deciding who to nudge.',
+  parameters: z.strictObject({
+    userNames: z.array(z.string()).optional().default([]).describe('Exact real names (from the User Directory). Leave empty to include all human participants in the topic.'),
+  }),
+  execute: async ({ userNames }, runContext?: RunContext<ConversationContext>) => {
+    if (!runContext) throw new Error('runContext not provided')
+    const { topic, userMap, callingUserTimezone } = runContext.context
+
+    const participants: Array<{ id: string, name: string }> = []
+    const unresolvedNames: string[] = []
+
+    if (userNames.length === 0) {
+      for (const userId of topic.state.userIds) {
+        if (userId === topic.botUserId) continue
+        const user = userMap.get(userId)
+        if (!user || user.isBot || !user.realName) continue
+        participants.push({ id: userId, name: user.realName })
+      }
+    } else {
+      userNames.forEach((requestedName) => {
+        const matchEntry = Array.from(userMap.entries()).find(([, user]) => {
+          const realName = user.realName || ''
+          return realName.localeCompare(requestedName, undefined, { sensitivity: 'base' }) === 0
+        })
+        if (!matchEntry || matchEntry[0] === topic.botUserId) {
+          unresolvedNames.push(requestedName)
+          return
+        }
+        const user = matchEntry[1]
+        if (user.isBot || !user.realName) {
+          unresolvedNames.push(requestedName)
+          return
+        }
+        participants.push({ id: matchEntry[0], name: user.realName })
+      })
+    }
+
+    if (participants.length === 0) {
+      const unresolvedStr = unresolvedNames.length > 0 ? ` Could not resolve: ${unresolvedNames.join(', ')}.` : ''
+      return `No human participants found to analyze.${unresolvedStr}`
+    }
+
+    const messageRows = await db
+      .select({ message: slackMessageTable, channel: slackChannelTable })
+      .from(slackMessageTable)
+      .leftJoin(slackChannelTable, eq(slackMessageTable.channelId, slackChannelTable.id))
+      .where(eq(slackMessageTable.topicId, topic.id))
+      .orderBy(slackMessageTable.timestamp)
+
+    const now = new Date()
+
+    const participantDetails = participants.map((participant) => {
+      const lastOutgoing = findLast(messageRows, (row) => {
+        if (row.message.userId !== topic.botUserId) return false
+        const channelUsers = row.channel?.userIds || []
+        return channelUsers.length === 1 && channelUsers.includes(participant.id)
+      })
+
+      const lastUserMessageOverall = findLast(messageRows, (row) => row.message.userId === participant.id)
+
+      const lastUserMessageAfterOutreach = lastOutgoing
+        ? findLast(messageRows, (row) => row.message.userId === participant.id && row.message.timestamp > lastOutgoing.message.timestamp)
+        : lastUserMessageOverall
+
+      const awaitingResponse = Boolean(lastOutgoing) && !lastUserMessageAfterOutreach
+
+      return {
+        name: participant.name,
+        status: awaitingResponse ? 'waiting' : 'responded',
+        lastOutreachIso: lastOutgoing ? lastOutgoing.message.timestamp.toISOString() : null,
+        lastOutreachLocal: lastOutgoing ? formatTimestampWithTimezone(lastOutgoing.message.timestamp, callingUserTimezone) : null,
+        lastOutreachText: lastOutgoing?.message.text ?? null,
+        lastResponseIso: lastUserMessageAfterOutreach ? lastUserMessageAfterOutreach.message.timestamp.toISOString() : null,
+        lastResponseLocal: lastUserMessageAfterOutreach ? formatTimestampWithTimezone(lastUserMessageAfterOutreach.message.timestamp, callingUserTimezone) : null,
+        lastResponseText: lastUserMessageAfterOutreach?.message.text ?? null,
+        lastResponseAgo: lastUserMessageAfterOutreach ? describeElapsedSince(lastUserMessageAfterOutreach.message.timestamp, now) : null,
+        waitingSince: awaitingResponse && lastOutgoing ? describeElapsedSince(lastOutgoing.message.timestamp, now) : null,
+        latestUserMessageText: lastUserMessageOverall?.message.text ?? null,
+      }
+    })
+
+    const pending = participantDetails
+      .filter((detail) => detail.status === 'waiting')
+      .map((detail) => detail.name)
+
+    const payload = {
+      participants: participantDetails,
+      pending,
+      unresolvedNames,
+      summary: pending.length > 0
+        ? `Waiting on: ${pending.join(', ')}`
+        : 'All tracked participants have responded since the last outreach.',
+    }
+
+    return JSON.stringify(payload, null, 2)
+  },
+})
+
+const baseInstructions = `You are Pivotal's queries assistant. Your responsibility is to answer user questions precisely and concisely using the conversation history, topic summary, and any tools provided. Always reply when a user reaches out—never leave a direct question unanswered.
+
+Guidelines:
+- Call the available tools whenever you need fresh or authoritative data (e.g., checkCalendarConnection for calendar status questions).
+- Prioritize factual responses grounded in the provided context or tool outputs.
+- When you lack sufficient information, say so explicitly and suggest the next step the platform or user could take to obtain it.
+- Reference the evidence you used ("conversation history", tool names, etc.) when it helps the user understand your answer.
+- Avoid fabricating details or making assumptions beyond what is supported.
+- When checking calendar status, call checkCalendarConnection and keep the response concise (✅/❌). If you can’t identify the linked account from the data available, tell the user to check their account settings.
+- For meeting-related questions (next meeting, meeting link, meeting purpose), call lookupMeetings to check Pivotal-managed meetings, and call getCalendarEvents when you need the full calendar (busy slots, external events) within a specific time window.
+- For cross-user availability or mutual free-time questions, call findCommonAvailability with an explicit ISO start and end window and include every person that should be considered.
+- For status updates (“Did Ben respond?”, “Who are we waiting on?”) or before sending follow-up nudges, call getParticipantResponseStatus and use its JSON payload to ground your answer and determine who still needs a ping.
+- When sending nudges, only include users who are actually outstanding according to the latest status data, and respect user requests when crafting the DM text.
+- When a user explicitly asks for the connection buttons—or clearly agrees that they want them—include "promptCalendarButtons": { "userName": "Exact Real Name" } in your final JSON so the platform knows who to prompt. Use the exact real name from the User Directory (e.g., "Anand Shah"). Add "force": true only if the user explicitly asks you to resend the buttons after already receiving them. Otherwise, omit this field.`
+
+export const queryAgent = new ConversationAgent({
+  name: 'queryAgent',
+  model: 'anthropic/claude-sonnet-4',
+  modelSettings: {
+    maxTokens: 1024,
+    temperature: 0.2,
+  },
+  tools: [
+    checkCalendarConnection,
+    lookupMeetings,
+    getCalendarEvents,
+    findCommonAvailability,
+    getParticipantResponseStatus,
+  ],
+  outputType: ConversationRes,
+  instructions: (runContext: RunContext<ConversationContext>) => {
+    const { topic, userMap } = runContext.context
+    const userDirectory = Array.from(userMap.values())
+      .filter((user) => !user.isBot && user.realName)
+      .map((user) => user.realName as string)
+      .sort()
+      .join(', ')
+
+    const topicSummary = topic.state.summary ?? 'No summary available.'
+
+    return `${baseInstructions}
+
+    User Directory (real names):
+${userDirectory || 'No human users known.'}
+
+    Current topic summary:
+${topicSummary}`
+  },
+})

--- a/src/agents/scheduling.ts
+++ b/src/agents/scheduling.ts
@@ -164,7 +164,7 @@ const updateUserCalendar = tool({
 })
 
 async function schedulingInstructions(runContext: RunContext<ConversationContext>) {
-const mainPrompt = `You are a scheduling assistant that helps coordinate meetings and events. Your job is to determine the next step in the scheduling process and generate appropriate responses.
+  const mainPrompt = `You are a scheduling assistant that helps coordinate meetings and events. Your job is to determine the next step in the scheduling process and generate appropriate responses.
 
 ## Important Timezone Instructions
 - ALWAYS include timezone abbreviations in parentheses next to ALL times you mention (e.g., "2pm (PST)" or "3:30pm (EST)")

--- a/src/agents/scheduling.ts
+++ b/src/agents/scheduling.ts
@@ -164,13 +164,16 @@ const updateUserCalendar = tool({
 })
 
 async function schedulingInstructions(runContext: RunContext<ConversationContext>) {
-  const mainPrompt = `You are a scheduling assistant that helps coordinate meetings and events. Your job is to determine the next step in the scheduling process and generate appropriate responses.
+const mainPrompt = `You are a scheduling assistant that helps coordinate meetings and events. Your job is to determine the next step in the scheduling process and generate appropriate responses.
 
 ## Important Timezone Instructions
 - ALWAYS include timezone abbreviations in parentheses next to ALL times you mention (e.g., "2pm (PST)" or "3:30pm (EST)")
 - When responding to a user, ALWAYS use their timezone for suggested times
 - Be explicit about timezone differences when they exist between participants
 - When proposing times to multiple users with different timezones, show the time in each user's timezone
+
+## Responsiveness
+- Always provide a helpful reply whenever the user sends a direct message or addresses you explicitly. Never leave a user query unanswered.
 
 ## Current Context
 You will receive:

--- a/src/integrations/google.ts
+++ b/src/integrations/google.ts
@@ -18,11 +18,13 @@ export async function getLinkedGoogleAccount(userId: string) {
     return null
   }
 
+  const accessToken = await getGoogleAccessToken(userId, linkedGoogleAccount.id)
+  if (accessToken === null) {
+    return null
+  }
+
   return {
     accountId: linkedGoogleAccount.accountId,
-    createdAt: linkedGoogleAccount.createdAt,
-    updatedAt: linkedGoogleAccount.updatedAt,
-    scope: linkedGoogleAccount.scope,
   }
 }
 

--- a/src/integrations/google.ts
+++ b/src/integrations/google.ts
@@ -18,13 +18,11 @@ export async function getLinkedGoogleAccount(userId: string) {
     return null
   }
 
-  const accessToken = await getGoogleAccessToken(userId, linkedGoogleAccount.id)
-  if (accessToken === null) {
-    return null
-  }
-
   return {
     accountId: linkedGoogleAccount.accountId,
+    createdAt: linkedGoogleAccount.createdAt,
+    updatedAt: linkedGoogleAccount.updatedAt,
+    scope: linkedGoogleAccount.scope,
   }
 }
 

--- a/src/meeting-artifacts.ts
+++ b/src/meeting-artifacts.ts
@@ -1,9 +1,11 @@
-import { and, asc, eq, isNull, lt } from 'drizzle-orm'
+import { and, asc, desc, eq, gt, isNull, lt } from 'drizzle-orm'
 import type { calendar_v3 } from 'googleapis'
 
 import db from './db/engine'
 import { meetingArtifactTable } from './db/schema/main'
 import type { MeetingArtifact } from './db/schema/main'
+import type { TopicWithState } from '@shared/api-types'
+import { getTopicWithState } from './utils'
 
 export interface MeetingArtifactUpsertParams {
   topicId: string
@@ -182,4 +184,60 @@ export async function markMeetingSummaryPosted(
       updatedAt: new Date(),
     })
     .where(eq(meetingArtifactTable.id, id))
+}
+
+export interface MeetingLookupOptions {
+  userIds: string[],
+  direction?: 'upcoming' | 'past',
+  summaryContains?: string | null,
+  limit?: number,
+}
+
+export interface MeetingLookupResult {
+  artifact: MeetingArtifact,
+  topic: TopicWithState,
+}
+
+export async function findMeetingsForUsers({
+  userIds,
+  direction = 'upcoming',
+  summaryContains,
+  limit = 3,
+}: MeetingLookupOptions): Promise<MeetingLookupResult[]> {
+  if (userIds.length === 0) return []
+
+  const now = new Date()
+  const fetchLimit = Math.max(limit * 5, 10)
+
+  const baseQuery = db.select().from(meetingArtifactTable)
+  const artifacts = await (direction === 'past'
+    ? baseQuery.where(lt(meetingArtifactTable.startTime, now)).orderBy(desc(meetingArtifactTable.startTime))
+    : baseQuery.where(gt(meetingArtifactTable.startTime, now)).orderBy(asc(meetingArtifactTable.startTime)))
+    .limit(fetchLimit)
+  const summaryNeedle = summaryContains?.toLowerCase() ?? null
+  const results: MeetingLookupResult[] = []
+
+  for (const artifact of artifacts) {
+    if (results.length >= limit) break
+
+    let topic: TopicWithState
+    try {
+      topic = await getTopicWithState(artifact.topicId)
+    } catch (error) {
+      console.warn('[MeetingArtifact] Failed to load topic state for', artifact.topicId, error)
+      continue
+    }
+
+    const matchesUser = topic.state.userIds.some((id) => userIds.includes(id))
+    if (!matchesUser) continue
+
+    if (summaryNeedle) {
+      const combined = `${artifact.summary ?? ''} ${topic.state.summary ?? ''}`.toLowerCase()
+      if (!combined.includes(summaryNeedle)) continue
+    }
+
+    results.push({ artifact, topic })
+  }
+
+  return results
 }

--- a/src/shared/api-types.ts
+++ b/src/shared/api-types.ts
@@ -15,7 +15,7 @@ export type TopicStateWithMessageTs = TopicState & {
   createdByMessageRawTs: string
 }
 
-export const WorkflowType = z.enum(['scheduling', 'meeting-prep', 'other'])
+export const WorkflowType = z.enum(['scheduling', 'meeting-prep', 'queries', 'other'])
 export type WorkflowType = z.infer<typeof WorkflowType>
 
 export const CalendarEvent = z.strictObject({


### PR DESCRIPTION
Summary:
We used to only have two workflows -- scheduling and meeting-prep. These are quite tightly scoped, which also means Pivotal cannot respond to many useful queries (it categorizes them as 'other' flows and ignores them). The queryAgent introdues a third workflow -- queries. This agent broadly introduces 4 types of capabilities: 
1) Calendar connection status (is my calendar connected? is parker's calendar connected?), 
2) Availability queries (what's blocking me after 3pm today? when is parker free tomorrow?), 
3) Meeting lookups (send me the link again for the sync with Kai. when does my meeting when Ben start and end?), 
4) Status tracking and nudges (who are we still waiting? how long has Parker been quiet? can you bump everyone who hasn't replied yet?).

In general, the queryAgent is also a catch-all for all the questions to pivotal that aren't explicitly for scheduling or meeting-prep. It will hopefully become the surface for wide-context queries, pending state tracking with GitHub integration and more work on transcripts.

Test Plan:
I tested each of these functionalities extensively in dev.