### PR TITLE
Add teamId parameter to Slack app authorization flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,16 @@ The application is a Slack bot with an integrated web interface that facilitates
 ## Frontend Conventions
 
 - Always use `cursor-pointer` and `disabled:cursor-default` in the className for buttons
+
+## Git Commit Template
+
+```
+[Concise commit message title]
+
+Summary:
+
+Test Plan:
+
+```
+- wrap commit messages at 72 characters
+- keep commit titles to 72 characters or less

--- a/src/auth/slack-app-installation-plugin.ts
+++ b/src/auth/slack-app-installation-plugin.ts
@@ -66,6 +66,15 @@ export function slackAppInstallationPlugin() {
           email: session.user.email,
         })
 
+        // Get user's organization teamId
+        const [userOrg] = await db.select({ slackTeamId: organizationTable.slackTeamId })
+          .from(memberTable)
+          .innerJoin(organizationTable, eq(memberTable.organizationId, organizationTable.id))
+          .where(eq(memberTable.userId, session.user.id))
+          .limit(1)
+
+        const additionalParams = userOrg?.slackTeamId ? { team: userOrg.slackTeamId } : undefined
+
         const installUrl = await createAuthorizationURL({
           id: '', // unused
           options: {
@@ -77,6 +86,7 @@ export function slackAppInstallationPlugin() {
           state,
           codeVerifier,
           scopes: SLACK_APP_SCOPES,
+          additionalParams,
         })
 
         return c.json({ installUrl: installUrl.toString() })


### PR DESCRIPTION
Summary:
Fetches the user's organization slackTeamId and passes it as the 'team' parameter in the Slack OAuth URL via additionalParams. This pre-selects the correct workspace during app installation, preventing users from installing the app in the wrong workspace. Also added git commit template documentation to CLAUDE.md.

Test Plan:
Manual testing of Slack app installation flow to verify workspace pre-selection