### PR TITLE
Fix social login token refresh behavior

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,6 +1,8 @@
 import { betterAuth } from 'better-auth'
 import { organization } from 'better-auth/plugins'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { refreshAccessToken } from 'better-auth/oauth2'
+import { symmetricDecrypt } from 'better-auth/crypto'
 import db from '../db/engine'
 import { betterAuthSchema } from '../db/schema/auth'
 import { slackTeamPlugin } from './slack-team-plugin'
@@ -18,6 +20,21 @@ export const baseURL = (
 
 if (process.env.PV_NODE_ENV === 'prod' && !process.env.PV_BETTER_AUTH_SECRET) {
   throw new Error('PV_BETTER_AUTH_SECRET required for production')
+}
+
+// Need this shim because better-auth doesn't decrypt the refreshToken by default
+function genRefreshAccessToken(tokenEndpoint: string, clientId: string, clientSecret: string) {
+  return async (encryptedToken: string) => {
+    const refreshToken = await symmetricDecrypt({
+      key: process.env.PV_BETTER_AUTH_SECRET!,
+      data: encryptedToken,
+    })
+    return refreshAccessToken({
+      refreshToken,
+      options: { clientId, clientSecret },
+      tokenEndpoint,
+    })
+  }
 }
 
 export const auth = betterAuth({
@@ -41,11 +58,21 @@ export const auth = betterAuth({
     slack: {
       clientId: process.env.PV_SLACK_CLIENT_ID!,
       clientSecret: process.env.PV_SLACK_CLIENT_SECRET!,
+      refreshAccessToken: genRefreshAccessToken(
+        'https://slack.com/api/openid.connect.token',
+        process.env.PV_SLACK_CLIENT_ID!,
+        process.env.PV_SLACK_CLIENT_SECRET!,
+      ),
     },
     github: {
       clientId: process.env.PV_GITHUB_CLIENT_ID!,
       clientSecret: process.env.PV_GITHUB_CLIENT_SECRET!,
       disableSignUp: true,
+      refreshAccessToken: genRefreshAccessToken(
+        'https://github.com/login/oauth/access_token',
+        process.env.PV_GITHUB_CLIENT_ID!,
+        process.env.PV_GITHUB_CLIENT_SECRET!,
+      ),
     },
     google: {
       clientId: process.env.PV_GOOGLE_CLIENT_ID!,
@@ -57,6 +84,11 @@ export const auth = betterAuth({
       ],
       accessType: 'offline', // Required to get a refresh token
       prompt: 'consent', // Required to get a refresh token
+      refreshAccessToken: genRefreshAccessToken(
+        'https://www.googleapis.com/oauth2/v4/token',
+        process.env.PV_GOOGLE_CLIENT_ID!,
+        process.env.PV_GOOGLE_CLIENT_SECRET!,
+      ),
     },
   },
   account: {


### PR DESCRIPTION
Summary:
The better-auth token refresh doesn't automatically decrypt the refreshToken if it is encrypted with the encryptOAuthTokens flag, so token refresh wasn't working. Fixed by overriding the refreshAccessToken method within our socialProviders configs.

Test Plan:
Tested refreshing the google token, and it works now