### PR TITLE
Remove user from existing organizations when creating a new org

### DIFF
--- a/src/auth/slack-team-plugin.ts
+++ b/src/auth/slack-team-plugin.ts
@@ -73,6 +73,16 @@ export function slackTeamPlugin() {
                 })
                 .returning()
 
+              // Remove user from any existing organizations
+              const removedOrgs = await db
+                .delete(memberTable)
+                .where(eq(memberTable.userId, userId))
+                .returning()
+
+              for (const membership of removedOrgs) {
+                c.context.logger.info(`Removed user ${userId} from organization ${membership.organizationId}`)
+              }
+
               // Add member to the new organization
               await auth.api.addMember({
                 body: {


### PR DESCRIPTION
Summary:
If a user is a member of an existing organization, when they log in with another organization they are creating, existing memberships must be deleted.

Test Plan:
Test on prod