### PR TITLE
Avoid resetting slack bot token in local or dev environment

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -7,16 +7,17 @@ import { slackTeamPlugin } from './slack-team-plugin'
 import { googleCalendarCallbackPlugin } from './google-calendar-callback-plugin'
 import { slackAppInstallationPlugin, SLACK_APP_SCOPES } from './slack-app-installation-plugin'
 import { githubAppInstallationPlugin } from './github-app-installation-plugin'
+import { isLocalEnv, isProdEnv } from '../utils'
 
 export { SLACK_APP_SCOPES, slackAppInstallationPlugin, githubAppInstallationPlugin }
 
 export const baseURL = (
-  process.env.PV_NODE_ENV === 'local' ?
+  isLocalEnv() ?
   'https://localhost:5173' :
   process.env.PV_BASE_URL || 'https://localhost:3009'
 )
 
-if (process.env.PV_NODE_ENV === 'prod' && !process.env.PV_BETTER_AUTH_SECRET) {
+if (isProdEnv() && !process.env.PV_BETTER_AUTH_SECRET) {
   throw new Error('PV_BETTER_AUTH_SECRET required for production')
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,18 +9,10 @@ import { readFileSync } from 'fs'
 
 import { connectSlackClient } from './slack-bot.ts'
 import { upsertFakeUser, mockSlackClient, BOT_USER_ID } from './local-helpers.ts'
-import { startAutoMessageCron } from './utils'
+import { isLocalEnv, isDevEnv, startAutoMessageCron } from './utils'
 import { startMeetingSummaryCron } from './meeting-summary-worker'
 import { apiRoutes } from './routes/api'
 import { localRoutes } from './routes/local'
-
-function isLocalEnv() {
-  return process.env.PV_NODE_ENV === 'local'
-}
-
-function isDevEnv() {
-  return process.env.PV_NODE_ENV === 'dev'
-}
 
 const PORT = isLocalEnv() ? 3001 : 3009
 const slackClient = isLocalEnv() ? mockSlackClient : await connectSlackClient()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,18 @@ export function tsToDate(ts: string): Date {
   return new Date(Number(ts) * 1000)
 }
 
+export function isLocalEnv() {
+  return process.env.PV_NODE_ENV === 'local'
+}
+
+export function isDevEnv() {
+  return process.env.PV_NODE_ENV === 'dev'
+}
+
+export function isProdEnv() {
+  return process.env.PV_NODE_ENV === 'prod'
+}
+
 export async function getTopicWithState(topicId: string): Promise<TopicWithState> {
   // Get the topic along with its most recent state
   const [row] = await db


### PR DESCRIPTION
Summary:
When we click the "Uninstall Bot" button on the token page, we don't want to invalidate the dev bot token, because it means everyone else's dev environment will be broken until they reinstall it.

As part of this, migrated all existing environment checks to use standard isLocalEnv, isDevEnv, and isProdEnv functions imported from src/utils.ts.

Test Plan:
Uninstalled and reinstalled the slack bot locally, then replaced the bot token in the DB with the old token from before the uninstall, and made sure I could still communicated with the Pivotal Dev bot on slack